### PR TITLE
add a cmake option to skip the leap version check, and skip in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,7 +92,7 @@ jobs:
           path: src
       - name: Build & Test
         run: |
-          cmake -S src -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=On
+          cmake -S src -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=On -DSYSTEM_ENABLE_LEAP_VERSION_CHECK=Off
           cmake --build build -- -j $(nproc)
           tar zcf build.tar.gz build
           ctest --test-dir build/tests --output-on-failure -j $(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ option(SYSTEM_CONFIGURABLE_WASM_LIMITS
 option(SYSTEM_BLOCKCHAIN_PARAMETERS
        "Enables use of the host functions activated by the BLOCKCHAIN_PARAMETERS protocol feature" ON)
 
+option(SYSTEM_ENABLE_LEAP_VERSION_CHECK
+      "Enables a configure-time check that the version of Leap's tester library is compatible with this project's unit tests" ON)
+
 ExternalProject_Add(
   contracts_project
   SOURCE_DIR ${CMAKE_SOURCE_DIR}/contracts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,13 +46,6 @@ elseif(UNIX)
 endif()
 set(SECP256K1_ROOT "/usr/local")
 
-if(APPLE)
-  set(OPENSSL_ROOT "/usr/local/opt/openssl")
-elseif(UNIX)
-  set(OPENSSL_ROOT "/usr/include/openssl")
-endif()
-set(SECP256K1_ROOT "/usr/local")
-
 option(BUILD_TESTS "Build unit tests" OFF)
 
 if(BUILD_TESTS)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,25 +4,27 @@ set(EOSIO_VERSION_MIN "3.1")
 set(EOSIO_VERSION_SOFT_MAX "3.1")
 # set(EOSIO_VERSION_HARD_MAX "")
 
-find_package(leap)
+find_package(leap REQUIRED)
 
 # Check the version of Leap
-set(VERSION_MATCH_ERROR_MSG "")
-eosio_check_version(VERSION_OUTPUT "${EOSIO_VERSION}" "${EOSIO_VERSION_MIN}" "${EOSIO_VERSION_SOFT_MAX}"
-                    "${EOSIO_VERSION_HARD_MAX}" VERSION_MATCH_ERROR_MSG)
-if(VERSION_OUTPUT STREQUAL "MATCH")
-  message(STATUS "Using Leap version ${EOSIO_VERSION}")
-elseif(VERSION_OUTPUT STREQUAL "WARN")
-  message(
-    WARNING
-      "Using Leap version ${EOSIO_VERSION} even though it exceeds the maximum supported version of ${EOSIO_VERSION_SOFT_MAX}; continuing with configuration, however build may fail.\nIt is recommended to use Leap version ${EOSIO_VERSION_SOFT_MAX}.x"
-  )
-else() # INVALID OR MISMATCH
-  message(
-    FATAL_ERROR
-      "Found Leap version ${EOSIO_VERSION} but it does not satisfy version requirements: ${VERSION_MATCH_ERROR_MSG}\nPlease use Leap version ${EOSIO_VERSION_SOFT_MAX}.x"
-  )
-endif(VERSION_OUTPUT STREQUAL "MATCH")
+if(SYSTEM_ENABLE_LEAP_VERSION_CHECK)
+  set(VERSION_MATCH_ERROR_MSG "")
+  eosio_check_version(VERSION_OUTPUT "${EOSIO_VERSION}" "${EOSIO_VERSION_MIN}" "${EOSIO_VERSION_SOFT_MAX}"
+                      "${EOSIO_VERSION_HARD_MAX}" VERSION_MATCH_ERROR_MSG)
+  if(VERSION_OUTPUT STREQUAL "MATCH")
+    message(STATUS "Using Leap version ${EOSIO_VERSION}")
+  elseif(VERSION_OUTPUT STREQUAL "WARN")
+    message(
+      WARNING
+        "Using Leap version ${EOSIO_VERSION} even though it exceeds the maximum supported version of ${EOSIO_VERSION_SOFT_MAX}; continuing with configuration, however build may fail.\nIt is recommended to use Leap version ${EOSIO_VERSION_SOFT_MAX}.x"
+    )
+  else() # INVALID OR MISMATCH
+    message(
+      FATAL_ERROR
+        "Found Leap version ${EOSIO_VERSION} but it does not satisfy version requirements: ${VERSION_MATCH_ERROR_MSG}\nPlease use Leap version ${EOSIO_VERSION_SOFT_MAX}.x"
+    )
+  endif()
+endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/contracts.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/contracts.hpp)
 


### PR DESCRIPTION
There is a version check that Leap's eosiotester is an expected compatible version and nominally it is useful and helpful, but it makes testing contracts with `main` of `leap` difficult even when it's expected to work. The check will balk that Leap is `4.0.0` while contracts is looking for `3.x` even though we haven't made any incompatible changes.

Change this check to be clutched in based on an `option()`, and enable the option by default (so no functional change by default).

And then disable the check in CI so that it's easier to spot check any version combination. This is maybe a little more contentious (maybe we won't notice we need to change eos-system-contracts before releasing Leap 4.0.0), so I'm curious for opinions on if it should be configurable instead.