### PR TITLE
some very minor eosio.token test cleanups

### DIFF
--- a/tests/eosio.token_tests.cpp
+++ b/tests/eosio.token_tests.cpp
@@ -114,7 +114,7 @@ public:
                         const string& symbolname ) {
       return push_action( owner, "close"_n, mvo()
            ( "owner", owner )
-           ( "symbol", "0,CERO" )
+           ( "symbol", symbolname )
       );
    }
 
@@ -324,15 +324,11 @@ BOOST_FIXTURE_TEST_CASE( transfer_tests, eosio_token_tester ) try {
    alice_balance = get_account("alice"_n, "0,CERO");
    REQUIRE_MATCHING_OBJECT( alice_balance, mvo()
       ("balance", "700 CERO")
-      ("frozen", 0)
-      ("whitelist", 1)
    );
 
    auto bob_balance = get_account("bob"_n, "0,CERO");
    REQUIRE_MATCHING_OBJECT( bob_balance, mvo()
       ("balance", "300 CERO")
-      ("frozen", 0)
-      ("whitelist", 1)
    );
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "overdrawn balance" ),


### PR DESCRIPTION
Noticed these minor outdated quirks while porting the token tests to a new token.