### PR TITLE
[3.1] Disable version check opts for leap and cdt

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,7 +92,7 @@ jobs:
           path: src
       - name: Build & Test
         run: |
-          cmake -S src -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=On
+          cmake -S src -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=On -DSYSTEM_ENABLE_LEAP_VERSION_CHECK=Off
           cmake --build build -- -j $(nproc)
           tar zcf build.tar.gz build
           ctest --test-dir build/tests --output-on-failure -j $(nproc)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,7 +92,7 @@ jobs:
           path: src
       - name: Build & Test
         run: |
-          cmake -S src -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=On -DSYSTEM_ENABLE_LEAP_VERSION_CHECK=Off
+          cmake -S src -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=On -DSYSTEM_ENABLE_LEAP_VERSION_CHECK=Off -DSYSTEM_ENABLE_CDT_VERSION_CHECK=Off
           cmake --build build -- -j $(nproc)
           tar zcf build.tar.gz build
           ctest --test-dir build/tests --output-on-failure -j $(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,9 @@ option(SYSTEM_BLOCKCHAIN_PARAMETERS
 option(SYSTEM_ENABLE_LEAP_VERSION_CHECK
       "Enables a configure-time check that the version of Leap's tester library is compatible with this project's unit tests" ON)
 
+option(SYSTEM_ENABLE_CDT_VERSION_CHECK
+      "Enables a configure-time check that the version of CDT is compatible with this project's contracts" ON)
+
 ExternalProject_Add(
   contracts_project
   SOURCE_DIR ${CMAKE_SOURCE_DIR}/contracts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ option(SYSTEM_CONFIGURABLE_WASM_LIMITS
 option(SYSTEM_BLOCKCHAIN_PARAMETERS
        "Enables use of the host functions activated by the BLOCKCHAIN_PARAMETERS protocol feature" ON)
 
+option(SYSTEM_ENABLE_LEAP_VERSION_CHECK
+      "Enables a configure-time check that the version of Leap's tester library is compatible with this project's unit tests" ON)
+
 ExternalProject_Add(
   contracts_project
   SOURCE_DIR ${CMAKE_SOURCE_DIR}/contracts

--- a/contracts/CMakeLists.txt
+++ b/contracts/CMakeLists.txt
@@ -8,29 +8,31 @@ option(SYSTEM_CONFIGURABLE_WASM_LIMITS
 option(SYSTEM_BLOCKCHAIN_PARAMETERS
        "Enables use of the host functions activated by the BLOCKCHAIN_PARAMETERS protocol feature" ON)
 
-find_package(cdt)
+find_package(cdt REQUIRED)
 
 set(CDT_VERSION_MIN "3.0")
 set(CDT_VERSION_SOFT_MAX "3.0")
 # set(CDT_VERSION_HARD_MAX "")
 
 # Check the version of CDT
-set(VERSION_MATCH_ERROR_MSG "")
-CDT_CHECK_VERSION(VERSION_OUTPUT "${CDT_VERSION}" "${CDT_VERSION_MIN}" "${CDT_VERSION_SOFT_MAX}"
-                    "${CDT_VERSION_HARD_MAX}" VERSION_MATCH_ERROR_MSG)
-if(VERSION_OUTPUT STREQUAL "MATCH")
-  message(STATUS "Using CDT version ${CDT_VERSION}")
-elseif(VERSION_OUTPUT STREQUAL "WARN")
-  message(
-    WARNING
-      "Using CDT version ${CDT_VERSION} even though it exceeds the maximum supported version of ${CDT_VERSION_SOFT_MAX}; continuing with configuration, however build may fail.\nIt is recommended to use CDT version ${CDT_VERSION_SOFT_MAX}.x"
-  )
-else() # INVALID OR MISMATCH
-  message(
-    FATAL_ERROR
-      "Found CDT version ${CDT_VERSION} but it does not satisfy version requirements: ${VERSION_MATCH_ERROR_MSG}\nPlease use CDT version ${CDT_VERSION_SOFT_MAX}.x"
-  )
-endif(VERSION_OUTPUT STREQUAL "MATCH")
+if(SYSTEM_ENABLE_CDT_VERSION_CHECK)
+  set(VERSION_MATCH_ERROR_MSG "")
+  CDT_CHECK_VERSION(VERSION_OUTPUT "${CDT_VERSION}" "${CDT_VERSION_MIN}" "${CDT_VERSION_SOFT_MAX}"
+                      "${CDT_VERSION_HARD_MAX}" VERSION_MATCH_ERROR_MSG)
+  if(VERSION_OUTPUT STREQUAL "MATCH")
+    message(STATUS "Using CDT version ${CDT_VERSION}")
+  elseif(VERSION_OUTPUT STREQUAL "WARN")
+    message(
+      WARNING
+        "Using CDT version ${CDT_VERSION} even though it exceeds the maximum supported version of ${CDT_VERSION_SOFT_MAX}; continuing with configuration, however build may fail.\nIt is recommended to use CDT version ${CDT_VERSION_SOFT_MAX}.x"
+    )
+  else() # INVALID OR MISMATCH
+    message(
+      FATAL_ERROR
+        "Found CDT version ${CDT_VERSION} but it does not satisfy version requirements: ${VERSION_MATCH_ERROR_MSG}\nPlease use CDT version ${CDT_VERSION_SOFT_MAX}.x"
+    )
+  endif()
+endif()
 
 set(ICON_BASE_URL "https://raw.githubusercontent.com/eosnetworkfoundation/eos-system-contracts/main/contracts/icons")
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,25 +4,27 @@ set(EOSIO_VERSION_MIN "3.1")
 set(EOSIO_VERSION_SOFT_MAX "3.1")
 # set(EOSIO_VERSION_HARD_MAX "")
 
-find_package(leap)
+find_package(leap REQUIRED)
 
 # Check the version of Leap
-set(VERSION_MATCH_ERROR_MSG "")
-eosio_check_version(VERSION_OUTPUT "${EOSIO_VERSION}" "${EOSIO_VERSION_MIN}" "${EOSIO_VERSION_SOFT_MAX}"
-                    "${EOSIO_VERSION_HARD_MAX}" VERSION_MATCH_ERROR_MSG)
-if(VERSION_OUTPUT STREQUAL "MATCH")
-  message(STATUS "Using Leap version ${EOSIO_VERSION}")
-elseif(VERSION_OUTPUT STREQUAL "WARN")
-  message(
-    WARNING
-      "Using Leap version ${EOSIO_VERSION} even though it exceeds the maximum supported version of ${EOSIO_VERSION_SOFT_MAX}; continuing with configuration, however build may fail.\nIt is recommended to use Leap version ${EOSIO_VERSION_SOFT_MAX}.x"
-  )
-else() # INVALID OR MISMATCH
-  message(
-    FATAL_ERROR
-      "Found Leap version ${EOSIO_VERSION} but it does not satisfy version requirements: ${VERSION_MATCH_ERROR_MSG}\nPlease use Leap version ${EOSIO_VERSION_SOFT_MAX}.x"
-  )
-endif(VERSION_OUTPUT STREQUAL "MATCH")
+if(SYSTEM_ENABLE_LEAP_VERSION_CHECK)
+  set(VERSION_MATCH_ERROR_MSG "")
+  eosio_check_version(VERSION_OUTPUT "${EOSIO_VERSION}" "${EOSIO_VERSION_MIN}" "${EOSIO_VERSION_SOFT_MAX}"
+                      "${EOSIO_VERSION_HARD_MAX}" VERSION_MATCH_ERROR_MSG)
+  if(VERSION_OUTPUT STREQUAL "MATCH")
+    message(STATUS "Using Leap version ${EOSIO_VERSION}")
+  elseif(VERSION_OUTPUT STREQUAL "WARN")
+    message(
+      WARNING
+        "Using Leap version ${EOSIO_VERSION} even though it exceeds the maximum supported version of ${EOSIO_VERSION_SOFT_MAX}; continuing with configuration, however build may fail.\nIt is recommended to use Leap version ${EOSIO_VERSION_SOFT_MAX}.x"
+    )
+  else() # INVALID OR MISMATCH
+    message(
+      FATAL_ERROR
+        "Found Leap version ${EOSIO_VERSION} but it does not satisfy version requirements: ${VERSION_MATCH_ERROR_MSG}\nPlease use Leap version ${EOSIO_VERSION_SOFT_MAX}.x"
+    )
+  endif()
+endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/contracts.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/contracts.hpp)
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
Backport:
 - add cmake option to enable/disable Leap eosiotester version check.
 - set SYSTEM_ENABLE_LEAP_VERSION_CHECK off in CI

Added:
 - add cmake option to enable/disable cdt version check.
 - set SYSTEM_ENABLE_CDT_VERSION_CHECK off in CI


## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
