### PR TITLE
[3.1] Fix for explicit time_point_sec conversion

### DIFF
--- a/tests/eosio.powerup_tests.cpp
+++ b/tests/eosio.powerup_tests.cpp
@@ -97,7 +97,7 @@ struct powerup_tester : eosio_system_tester {
       config.net.current_weight_ratio = powerup_frac;
       config.net.target_weight_ratio  = powerup_frac / 100;
       config.net.assumed_stake_weight = stake_weight;
-      config.net.target_timestamp     = control->head_block_time() + fc::days(100);
+      config.net.target_timestamp     = time_point_sec(control->head_block_time() + fc::days(100));
       config.net.exponent             = 2;
       config.net.decay_secs           = fc::days(1).to_seconds();
       config.net.min_price            = asset::from_string("0.0000 TST");
@@ -106,7 +106,7 @@ struct powerup_tester : eosio_system_tester {
       config.cpu.current_weight_ratio = powerup_frac;
       config.cpu.target_weight_ratio  = powerup_frac / 100;
       config.cpu.assumed_stake_weight = stake_weight;
-      config.cpu.target_timestamp     = control->head_block_time() + fc::days(100);
+      config.cpu.target_timestamp     = time_point_sec(control->head_block_time() + fc::days(100));
       config.cpu.exponent             = 2;
       config.cpu.decay_secs           = fc::days(1).to_seconds();
       config.cpu.min_price            = asset::from_string("0.0000 TST");
@@ -287,9 +287,9 @@ BOOST_FIXTURE_TEST_CASE(config_tests, powerup_tester) try {
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_timestamp does not have a default value"),
                        configbw(make_config([&](auto& c) { c.net.target_timestamp = {}; })));
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_timestamp must be in the future"),
-                       configbw(make_config([&](auto& c) { c.net.target_timestamp = control->head_block_time(); })));
+                       configbw(make_config([&](auto& c) { c.net.target_timestamp = time_point_sec(control->head_block_time()); })));
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_timestamp must be in the future"), configbw(make_config([&](auto& c) {
-                          c.net.target_timestamp = control->head_block_time() - fc::seconds(1);
+                          c.net.target_timestamp = time_point_sec(control->head_block_time() - fc::seconds(1));
                        })));
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("exponent must be >= 1"),
                        configbw(make_config([&](auto& c) { c.net.exponent = .999; })));
@@ -332,9 +332,9 @@ BOOST_FIXTURE_TEST_CASE(config_tests, powerup_tester) try {
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_timestamp does not have a default value"),
                        configbw(make_config([&](auto& c) { c.cpu.target_timestamp = {}; })));
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_timestamp must be in the future"),
-                       configbw(make_config([&](auto& c) { c.cpu.target_timestamp = control->head_block_time(); })));
+                       configbw(make_config([&](auto& c) { c.cpu.target_timestamp = time_point_sec(control->head_block_time()); })));
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("target_timestamp must be in the future"), configbw(make_config([&](auto& c) {
-                          c.cpu.target_timestamp = control->head_block_time() - fc::seconds(1);
+                          c.cpu.target_timestamp = time_point_sec(control->head_block_time() - fc::seconds(1));
                        })));
    BOOST_REQUIRE_EQUAL(wasm_assert_msg("exponent must be >= 1"),
                        configbw(make_config([&](auto& c) { c.cpu.exponent = .999; })));
@@ -374,12 +374,12 @@ BOOST_FIXTURE_TEST_CASE(weight_tests, powerup_tester) try {
                           config.net.current_weight_ratio = net_start;
                           config.net.target_weight_ratio  = net_target;
                           config.net.assumed_stake_weight = stake_weight;
-                          config.net.target_timestamp     = control->head_block_time() + fc::days(10);
+                          config.net.target_timestamp     = time_point_sec(control->head_block_time() + fc::days(10));
 
                           config.cpu.current_weight_ratio = cpu_start;
                           config.cpu.target_weight_ratio  = cpu_target;
                           config.cpu.assumed_stake_weight = stake_weight;
-                          config.cpu.target_timestamp     = control->head_block_time() + fc::days(20);
+                          config.cpu.target_timestamp     = time_point_sec(control->head_block_time() + fc::days(20));
                        })));
 
    int64_t net;
@@ -415,8 +415,8 @@ BOOST_FIXTURE_TEST_CASE(weight_tests, powerup_tester) try {
       int i = 7;
       produce_block(fc::days(1) - fc::milliseconds(500));
       BOOST_REQUIRE_EQUAL("", configbw(make_default_config([&](powerup_config& config) {
-                             config.net.target_timestamp = control->head_block_time() + fc::days(30);
-                             config.cpu.target_timestamp = control->head_block_time() + fc::days(40);
+                             config.net.target_timestamp = time_point_sec(control->head_block_time() + fc::days(30));
+                             config.cpu.target_timestamp = time_point_sec(control->head_block_time() + fc::days(40));
                           })));
       net_start = net = net_start + i * (net_target - net_start) / 10;
       cpu_start = cpu = cpu_start + i * (cpu_target - cpu_start) / 20;
@@ -471,9 +471,10 @@ BOOST_FIXTURE_TEST_CASE(weight_tests, powerup_tester) try {
    // Move transition time to immediate future
    {
       produce_block(fc::days(1) - fc::milliseconds(500));
+      time_point_sec tps(control->head_block_time() + fc::milliseconds(1000));
       BOOST_REQUIRE_EQUAL("", configbw(make_default_config([&](powerup_config& config) {
-                             config.net.target_timestamp = control->head_block_time() + fc::milliseconds(1000);
-                             config.cpu.target_timestamp = control->head_block_time() + fc::milliseconds(1000);
+                             config.net.target_timestamp = tps;
+                             config.cpu.target_timestamp = tps;
                           })));
       produce_blocks(2);
    }


### PR DESCRIPTION
Backports Fix for explicit time_point_sec conversion without the bump to the version.

reference: https://github.com/eosnetworkfoundation/eos-system-contracts/pull/75 and commit: 97d3faab7ee6995dd2d310e94e3f3dcb368ea602