### PR TITLE
[3.2] Bump Leap v5 

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 set(EOSIO_VERSION_MIN "3.1")
-set(EOSIO_VERSION_SOFT_MAX "4.1")
+set(EOSIO_VERSION_SOFT_MAX "5.0")
 # set(EOSIO_VERSION_HARD_MAX "")
 
 find_package(leap REQUIRED)


### PR DESCRIPTION
Allow system contracts to build against Leap 5. Targeted to release/3.2 branch
