### PR TITLE
Transferable RAM

### DIFF
--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -1428,6 +1428,7 @@ namespace eosiosystem {
          using buyram_action = eosio::action_wrapper<"buyram"_n, &system_contract::buyram>;
          using buyrambytes_action = eosio::action_wrapper<"buyrambytes"_n, &system_contract::buyrambytes>;
          using sellram_action = eosio::action_wrapper<"sellram"_n, &system_contract::sellram>;
+         using ramtransfer_action = eosio::action_wrapper<"ramtransfer"_n, &system_contract::ramtransfer>;
          using refund_action = eosio::action_wrapper<"refund"_n, &system_contract::refund>;
          using regproducer_action = eosio::action_wrapper<"regproducer"_n, &system_contract::regproducer>;
          using regproducer2_action = eosio::action_wrapper<"regproducer2"_n, &system_contract::regproducer2>;

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -1131,6 +1131,16 @@ namespace eosiosystem {
          void ramtransfer( const name& from, const name& to, int64_t bytes );
 
          /**
+          * Logging for ram changes
+          *
+          * @param owner - the ram owner account,
+          * @param bytes - the bytes balance change,
+          * @param ram_bytes - the ram bytes held by owner after the action.
+          */
+         [[eosio::action]]
+         void logramchange( const name& owner, int64_t bytes, int64_t ram_bytes );
+
+         /**
           * Refund action, this action is called after the delegation-period to claim all pending
           * unstaked tokens belonging to owner.
           *
@@ -1429,6 +1439,7 @@ namespace eosiosystem {
          using buyrambytes_action = eosio::action_wrapper<"buyrambytes"_n, &system_contract::buyrambytes>;
          using sellram_action = eosio::action_wrapper<"sellram"_n, &system_contract::sellram>;
          using ramtransfer_action = eosio::action_wrapper<"ramtransfer"_n, &system_contract::ramtransfer>;
+         using logramchange_action = eosio::action_wrapper<"logramchange"_n, &system_contract::logramchange>;
          using refund_action = eosio::action_wrapper<"refund"_n, &system_contract::refund>;
          using regproducer_action = eosio::action_wrapper<"regproducer"_n, &system_contract::regproducer>;
          using regproducer2_action = eosio::action_wrapper<"regproducer2"_n, &system_contract::regproducer2>;

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -1507,7 +1507,9 @@ namespace eosiosystem {
          void changebw( name from, const name& receiver,
                         const asset& stake_net_quantity, const asset& stake_cpu_quantity, bool transfer );
          void update_voting_power( const name& voter, const asset& total_update );
-         void set_resource_ram_bytes_limits( const name& owner, int64_t new_ram_bytes );
+         void set_resource_ram_bytes_limits( const name& owner );
+         void reduce_ram( const name& owner, int64_t bytes );
+         void add_ram( const name& owner, int64_t bytes );
 
          // defined in voting.cpp
          void register_producer( const name& producer, const eosio::block_signing_authority& producer_authority, const std::string& url, uint16_t location );

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -1121,6 +1121,16 @@ namespace eosiosystem {
          void sellram( const name& account, int64_t bytes );
 
          /**
+          * Transfer ram action, reduces sender's quota by bytes and increase receiver's quota by bytes.
+          *
+          * @param from - the ram sender account,
+          * @param to - the ram receiver account,
+          * @param bytes - the amount of ram to transfer in bytes.
+          */
+         [[eosio::action]]
+         void ramtransfer( const name& from, const name& to, int64_t bytes );
+
+         /**
           * Refund action, this action is called after the delegation-period to claim all pending
           * unstaked tokens belonging to owner.
           *
@@ -1496,6 +1506,7 @@ namespace eosiosystem {
          void changebw( name from, const name& receiver,
                         const asset& stake_net_quantity, const asset& stake_cpu_quantity, bool transfer );
          void update_voting_power( const name& voter, const asset& total_update );
+         void set_resource_ram_bytes_limits( const name& owner, int64_t new_ram_bytes );
 
          // defined in voting.cpp
          void register_producer( const name& producer, const eosio::block_signing_authority& producer_authority, const std::string& url, uint16_t location );

--- a/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
+++ b/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
@@ -413,6 +413,17 @@ icon: @ICON_BASE_URL@/@RESOURCE_ICON_URI@
 
 Sell {{bytes}} bytes of unused RAM from account {{account}} at market price. This transaction will incur a 0.5% fee on the proceeds which depend on market rates.
 
+<h1 class="contract">ramtransfer</h1>
+
+---
+spec_version: "0.2.0"
+title: Transfer RAM from Account
+summary: 'Transfer unused RAM from {{nowrap from}} to {{nowrap to}}'
+icon: @ICON_BASE_URL@/@RESOURCE_ICON_URI@
+---
+
+Transfer {{bytes}} bytes of unused RAM from account {{from}} to account {{to}}.
+
 <h1 class="contract">sellrex</h1>
 
 ---

--- a/contracts/eosio.system/src/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/src/delegate_bandwidth.cpp
@@ -154,6 +154,7 @@ namespace eosiosystem {
    void system_contract::ramtransfer( const name& from, const name& to, int64_t bytes ) {
       require_auth( from );
       update_ram_supply();
+      require_recipient( to );
 
       check( bytes > 0, "cannot sell negative byte" );
       check(is_account(to), "to account does not exist");
@@ -188,7 +189,7 @@ namespace eosiosystem {
       set_resource_ram_bytes_limits( to_itr->owner, to_itr->ram_bytes );
    }
 
-   void set_resource_ram_bytes_limits( const name& owner, int64_t new_ram_bytes ) {
+   void system_contract::set_resource_ram_bytes_limits( const name& owner, int64_t new_ram_bytes ) {
       auto voter_itr = _voters.find( owner.value );
       if ( voter_itr == _voters.end() || !has_field( voter_itr->flags1, voter_info::flags1_fields::ram_managed ) ) {
          int64_t ram_bytes, net, cpu;

--- a/contracts/eosio.system/src/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/src/delegate_bandwidth.cpp
@@ -129,6 +129,7 @@ namespace eosiosystem {
       update_ram_supply();
       reduce_ram( from, bytes );
       add_ram( to, bytes );
+      require_recipient( from );
       require_recipient( to );
    }
 

--- a/contracts/eosio.system/src/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/src/delegate_bandwidth.cpp
@@ -133,6 +133,13 @@ namespace eosiosystem {
       require_recipient( to );
    }
 
+   [[eosio::action]]
+   void system_contract::logramchange( const name& owner, int64_t bytes, int64_t ram_bytes )
+   {
+      require_auth( get_self() );
+      require_recipient( owner );
+   }
+
    void system_contract::reduce_ram( const name& owner, int64_t bytes ) {
       check( bytes > 0, "cannot reduce negative byte" );
       user_resources_table userres( get_self(), owner.value );
@@ -144,6 +151,10 @@ namespace eosiosystem {
           res.ram_bytes -= bytes;
       });
       set_resource_ram_bytes_limits( owner );
+
+      // logging
+      system_contract::logramchange_action logramchange_act{ get_self(), { {get_self(), active_permission} }};
+      logramchange_act.send( owner, -bytes, res_itr->ram_bytes );
    }
 
    void system_contract::add_ram( const name& owner, int64_t bytes ) {
@@ -164,6 +175,10 @@ namespace eosiosystem {
          });
       }
       set_resource_ram_bytes_limits( owner );
+
+      // logging
+      system_contract::logramchange_action logramchange_act{ get_self(), { {get_self(), active_permission} } };
+      logramchange_act.send( owner, bytes, res_itr->ram_bytes );
    }
 
    void system_contract::set_resource_ram_bytes_limits( const name& owner ) {

--- a/tests/eosio.system_ram_tests.cpp
+++ b/tests/eosio.system_ram_tests.cpp
@@ -1,0 +1,42 @@
+#include <boost/test/unit_test.hpp>
+#include <eosio/chain/contract_table_objects.hpp>
+#include <eosio/chain/global_property_object.hpp>
+#include <eosio/chain/resource_limits.hpp>
+#include <eosio/chain/wast_to_wasm.hpp>
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+#include <fc/log/logger.hpp>
+#include <eosio/chain/exceptions.hpp>
+
+#include "eosio.system_tester.hpp"
+
+using namespace eosio_system;
+
+BOOST_AUTO_TEST_SUITE(eosio_system_ram_tests)
+
+BOOST_FIXTURE_TEST_CASE( ram_transfer, eosio_system_tester ) try {
+   const std::vector<account_name> accounts = { "alice"_n, "bob"_n };
+   create_accounts_with_resources( accounts );
+   const account_name alice = accounts[0];
+   const account_name bob = accounts[1];
+
+   transfer( config::system_account_name, alice, core_sym::from_string("100.0000"), config::system_account_name );
+   transfer( config::system_account_name, bob, core_sym::from_string("100.0000"), config::system_account_name );
+   BOOST_REQUIRE_EQUAL( success(), buyrambytes( alice, alice, 10000 ) );
+   BOOST_REQUIRE_EQUAL( success(), buyrambytes( bob, bob, 10000 ) );
+
+   const uint64_t alice_before = get_total_stake( alice )["ram_bytes"].as_uint64();
+   const uint64_t bob_before = get_total_stake( bob )["ram_bytes"].as_uint64();
+
+   BOOST_REQUIRE_EQUAL( success(), ramtransfer( alice, bob, 1000 ) );
+
+   const uint64_t alice_after = get_total_stake( alice )["ram_bytes"].as_uint64();
+   const uint64_t bob_after = get_total_stake( bob )["ram_bytes"].as_uint64();
+
+   BOOST_REQUIRE_EQUAL( alice_before - 1000, alice_after );
+   BOOST_REQUIRE_EQUAL( bob_before + 1000, bob_after );
+
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -254,10 +254,10 @@ public:
    }
 
    action_result ramtransfer( const account_name& from, const account_name& to, uint32_t bytes ) {
-      return push_action( payer, "ramtransfer"_n, mvo()( "from",from)("to",to)("bytes",bytes) );
+      return push_action( from, "ramtransfer"_n, mvo()( "from",from)("to",to)("bytes",bytes) );
    }
    action_result ramtransfer( std::string_view from, std::string_view to, uint32_t bytes ) {
-      return ramtransfer( payer, "ramtransfer"_n, mvo()( "from",from)("to",to)("bytes",bytes) );
+      return ramtransfer( account_name(from), account_name(to), bytes );
    }
 
    action_result buyrambytes( const account_name& payer, account_name receiver, uint32_t numbytes ) {

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -253,6 +253,13 @@ public:
       return buyram( account_name(payer), account_name(receiver), eosin );
    }
 
+   action_result ramtransfer( const account_name& from, const account_name& to, uint32_t bytes ) {
+      return push_action( payer, "ramtransfer"_n, mvo()( "from",from)("to",to)("bytes",bytes) );
+   }
+   action_result ramtransfer( std::string_view from, std::string_view to, uint32_t bytes ) {
+      return push_action( payer, "ramtransfer"_n, mvo()( "from",from)("to",to)("bytes",bytes) );
+   }
+
    action_result buyrambytes( const account_name& payer, account_name receiver, uint32_t numbytes ) {
       return push_action( payer, "buyrambytes"_n, mvo()( "payer",payer)("receiver",receiver)("bytes",numbytes) );
    }
@@ -707,7 +714,7 @@ public:
       memcpy( data.data(), itr->value.data(), data.size() );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "rex_return_buckets", data, abi_serializer::create_yield_function(abi_serializer_max_time) );
    }
-      
+
    void setup_rex_accounts( const std::vector<account_name>& accounts,
                             const asset& init_balance,
                             const asset& net = core_sym::from_string("80.0000"),

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -257,7 +257,7 @@ public:
       return push_action( payer, "ramtransfer"_n, mvo()( "from",from)("to",to)("bytes",bytes) );
    }
    action_result ramtransfer( std::string_view from, std::string_view to, uint32_t bytes ) {
-      return push_action( payer, "ramtransfer"_n, mvo()( "from",from)("to",to)("bytes",bytes) );
+      return ramtransfer( payer, "ramtransfer"_n, mvo()( "from",from)("to",to)("bytes",bytes) );
    }
 
    action_result buyrambytes( const account_name& payer, account_name receiver, uint32_t numbytes ) {

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -4132,13 +4132,13 @@ BOOST_FIXTURE_TEST_CASE( ram_transfer, eosio_system_tester ) try {
    transfer( config::system_account_name, alice, core_sym::from_string("100.0000"), config::system_account_name );
    BOOST_REQUIRE_EQUAL( success(), buyrambytes( alice, alice, 1000 ) );
 
-   const uint64_t alice_before = get_total_stake( alice )["ram_bytes"];
-   const uint64_t bob_before = get_total_stake( bob )["ram_bytes"];
+   const uint64_t alice_before = get_total_stake( alice )["ram_bytes"].as_uint64();
+   const uint64_t bob_before = get_total_stake( bob )["ram_bytes"].as_uint64();
 
    BOOST_REQUIRE_EQUAL( success(), ramtransfer( alice, bob, 1000 ) );
 
-   const uint64_t alice_after = get_total_stake( alice )["ram_bytes"];
-   const uint64_t bob_after = get_total_stake( bob )["ram_bytes"];
+   const uint64_t alice_after = get_total_stake( alice )["ram_bytes"].as_uint64();
+   const uint64_t bob_after = get_total_stake( bob )["ram_bytes"].as_uint64();
 
    BOOST_REQUIRE_EQUAL( alice_before - 1000, alice_after );
    BOOST_REQUIRE_EQUAL( bob_before + 1000, bob_after );

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -4124,6 +4124,27 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_small_rex, eosio_system_tester ) try {
 } FC_LOG_AND_RETHROW()
 
 
+// RAM transfer
+BOOST_FIXTURE_TEST_CASE( ram_transfer, eosio_system_tester ) try {
+   const name alice = "alice1111111"_n;
+   const name bob = "bobbyaccount"_n;
+
+   transfer( config::system_account_name, alice, core_sym::from_string("100.0000"), config::system_account_name );
+   BOOST_REQUIRE_EQUAL( success(), buyrambytes( alice, alice, 1000 ) );
+
+   const uint64_t alice_before = get_total_stake( alice )["ram_bytes"];
+   const uint64_t bob_before = get_total_stake( bob )["ram_bytes"];
+
+   BOOST_REQUIRE_EQUAL( success(), ramtransfer( alice, bob, 1000 ) );
+
+   const uint64_t alice_after = get_total_stake( alice )["ram_bytes"];
+   const uint64_t bob_after = get_total_stake( bob )["ram_bytes"];
+
+   BOOST_REQUIRE_EQUAL( alice_before - 1000, alice_after );
+   BOOST_REQUIRE_EQUAL( bob_before + 1000, bob_after );
+
+} FC_LOG_AND_RETHROW()
+
 BOOST_FIXTURE_TEST_CASE( unstake_buy_rex, eosio_system_tester, * boost::unit_test::tolerance(1e-10) ) try {
 
    const int64_t ratio        = 10000;

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -4123,32 +4123,6 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_small_rex, eosio_system_tester ) try {
 
 } FC_LOG_AND_RETHROW()
 
-
-// RAM transfer
-BOOST_FIXTURE_TEST_CASE( ram_transfer, eosio_system_tester ) try {
-   const std::vector<account_name> accounts = { "alice"_n, "bob"_n };
-   create_accounts_with_resources( accounts );
-   const account_name alice = accounts[0];
-   const account_name bob = accounts[1];
-
-   transfer( config::system_account_name, alice, core_sym::from_string("100.0000"), config::system_account_name );
-   transfer( config::system_account_name, bob, core_sym::from_string("100.0000"), config::system_account_name );
-   BOOST_REQUIRE_EQUAL( success(), buyrambytes( alice, alice, 10000 ) );
-   BOOST_REQUIRE_EQUAL( success(), buyrambytes( bob, bob, 10000 ) );
-
-   const uint64_t alice_before = get_total_stake( alice )["ram_bytes"].as_uint64();
-   const uint64_t bob_before = get_total_stake( bob )["ram_bytes"].as_uint64();
-
-   BOOST_REQUIRE_EQUAL( success(), ramtransfer( alice, bob, 1000 ) );
-
-   const uint64_t alice_after = get_total_stake( alice )["ram_bytes"].as_uint64();
-   const uint64_t bob_after = get_total_stake( bob )["ram_bytes"].as_uint64();
-
-   BOOST_REQUIRE_EQUAL( alice_before - 1000, alice_after );
-   BOOST_REQUIRE_EQUAL( bob_before + 1000, bob_after );
-
-} FC_LOG_AND_RETHROW()
-
 BOOST_FIXTURE_TEST_CASE( unstake_buy_rex, eosio_system_tester, * boost::unit_test::tolerance(1e-10) ) try {
 
    const int64_t ratio        = 10000;

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -3929,7 +3929,7 @@ BOOST_FIXTURE_TEST_CASE( rex_rounding_issue, eosio_system_tester ) try {
    auto rent_and_go = [&] (int cnt) {
       for(auto& rb : rexborrowers) {
          BOOST_REQUIRE_EQUAL( success(),
-                        push_action( rb, "rentcpu"_n, 
+                        push_action( rb, "rentcpu"_n,
                         mvo()
                         ("from", rb)
                         ("receiver", rb)
@@ -4126,11 +4126,15 @@ BOOST_FIXTURE_TEST_CASE( buy_sell_small_rex, eosio_system_tester ) try {
 
 // RAM transfer
 BOOST_FIXTURE_TEST_CASE( ram_transfer, eosio_system_tester ) try {
-   const name alice = "alice1111111"_n;
-   const name bob = "bobbyaccount"_n;
+   const std::vector<account_name> accounts = { "alice"_n, "bob"_n };
+   create_accounts_with_resources( accounts );
+   const account_name alice = accounts[0];
+   const account_name bob = accounts[1];
 
    transfer( config::system_account_name, alice, core_sym::from_string("100.0000"), config::system_account_name );
-   BOOST_REQUIRE_EQUAL( success(), buyrambytes( alice, alice, 1000 ) );
+   transfer( config::system_account_name, bob, core_sym::from_string("100.0000"), config::system_account_name );
+   BOOST_REQUIRE_EQUAL( success(), buyrambytes( alice, alice, 10000 ) );
+   BOOST_REQUIRE_EQUAL( success(), buyrambytes( bob, bob, 10000 ) );
 
    const uint64_t alice_before = get_total_stake( alice )["ram_bytes"].as_uint64();
    const uint64_t bob_before = get_total_stake( bob )["ram_bytes"].as_uint64();
@@ -5553,7 +5557,7 @@ BOOST_FIXTURE_TEST_CASE( b1_vesting, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( wasm_assert_msg("b1 can only claim their tokens over 10 years"),
                         unstake( b1, b1, final_amount, final_amount ) );
 
-   BOOST_REQUIRE_EQUAL( wasm_assert_msg("must vote for at least 21 producers or for a proxy before buying REX"), 
+   BOOST_REQUIRE_EQUAL( wasm_assert_msg("must vote for at least 21 producers or for a proxy before buying REX"),
                         unstaketorex( b1, b1, final_amount - small_amount, final_amount - small_amount ) );
 
    BOOST_REQUIRE_EQUAL( error("missing authority of eosio"), vote( b1, { }, "proxyaccount"_n ) );


### PR DESCRIPTION
## Change Description

New RAM system contract action to transfer RAM from one account to another without any fees.

### Preconditions
- `from` must have sufficient `ram_bytes` prior to transfer
- `from` decrease `ram_bytes` by `bytes`
- `to` must exists
- `to` account can be a contract
- `to` account can have zero available RAM bytes
- `to` increase `ram_bytes` by `bytes`
- handle `ram_managed` accounts

## API Changes

#### ACTION: `ramtransfer`

- `from {name}`
- `to {name}`
- `bytes {int64}`
- `memo {string}` (via https://github.com/eosnetworkfoundation/eos-system-contracts/pull/104)

### `logramchange`
```c++
 /**
  * Logging for ram changes
  *
  * @param owner - the ram owner account,
  * @param bytes - the bytes balance change,
  * @param ram_bytes - the ram bytes held by owner after the action.
  */
 [[eosio::action]]
 void logramchange( const name& owner, int64_t bytes, int64_t ram_bytes );
```

### Helper functions
- `reduce_ram`
- `add_ram`
- `set_resource_ram_bytes_limits`

### Requirements
- Charges 0% fee to transfer
- Only uncommited RAM can be transferred
- Notify `to` & `from` using `require_recipient`
- Memo cannot exceed 256 bytes

### Usecases

1. Improves EOS account creation:
  a. Create `newaccount` using `ramtransfer` instead of `buyram` or `buyrambytes`

2. Improves RAM token wrapper development:
  a. Receive RAM without buy/sell actions (no fees to transferring RAM)
  b. Existing RAM supply can be transferred to existing RAM token wrappers
  c. DeFi composability using `memo` field


## Documentation Additions
- **system_contract**
  - [buyram](https://github.com/eosnetworkfoundation/eos-system-contracts/blob/c6113dbec2282825ce8d1fb6396fe82500af9019/contracts/eosio.system/src/delegate_bandwidth.cpp#L43-L103)
  - [sellram](https://github.com/eosnetworkfoundation/eos-system-contracts/blob/c6113dbec2282825ce8d1fb6396fe82500af9019/contracts/eosio.system/src/delegate_bandwidth.cpp#L111-L159)
- **resource_limits_manager**
  - [verify_account_ram_usage](https://github.com/AntelopeIO/leap/blob/96965434094d8d9a3808c7060061eadf5b632b8d/libraries/chain/resource_limits.cpp#L232-L242)
  - [set_account_limits](https://github.com/AntelopeIO/leap/blob/96965434094d8d9a3808c7060061eadf5b632b8d/libraries/chain/resource_limits.cpp#L249-L270)
  - [get_account_limits](https://github.com/AntelopeIO/leap/blob/96965434094d8d9a3808c7060061eadf5b632b8d/libraries/chain/resource_limits.cpp#L303-L315)
- **privileged**
  - [set_resource_limits](https://github.com/AntelopeIO/leap/blob/96965434094d8d9a3808c7060061eadf5b632b8d/libraries/chain/webassembly/privileged.cpp#L27-L35)
  - [get_resource_limits](https://github.com/AntelopeIO/leap/blob/96965434094d8d9a3808c7060061eadf5b632b8d/libraries/chain/webassembly/privileged.cpp#L37C20-L42)