### PR TITLE
Burn RAM

### DIFF
--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -1131,6 +1131,15 @@ namespace eosiosystem {
          void ramtransfer( const name& from, const name& to, int64_t bytes );
 
          /**
+          * Burn ram action, reduces owner's quota by bytes.
+          *
+          * @param owner - the ram owner account,
+          * @param bytes - the amount of ram to be burned in bytes.
+          */
+         [[eosio::action]]
+         void ramburn( const name& owner, int64_t bytes );
+
+         /**
           * Refund action, this action is called after the delegation-period to claim all pending
           * unstaked tokens belonging to owner.
           *
@@ -1429,6 +1438,7 @@ namespace eosiosystem {
          using buyrambytes_action = eosio::action_wrapper<"buyrambytes"_n, &system_contract::buyrambytes>;
          using sellram_action = eosio::action_wrapper<"sellram"_n, &system_contract::sellram>;
          using ramtransfer_action = eosio::action_wrapper<"ramtransfer"_n, &system_contract::ramtransfer>;
+         using ramburn_action = eosio::action_wrapper<"ramburn"_n, &system_contract::ramburn>;
          using refund_action = eosio::action_wrapper<"refund"_n, &system_contract::refund>;
          using regproducer_action = eosio::action_wrapper<"regproducer"_n, &system_contract::regproducer>;
          using regproducer2_action = eosio::action_wrapper<"regproducer2"_n, &system_contract::regproducer2>;

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -1125,19 +1125,21 @@ namespace eosiosystem {
           *
           * @param from - the ram sender account,
           * @param to - the ram receiver account,
-          * @param bytes - the amount of ram to transfer in bytes.
+          * @param bytes - the amount of ram to transfer in bytes,
+          * @param memo - the memo string to accompany the transaction.
           */
          [[eosio::action]]
-         void ramtransfer( const name& from, const name& to, int64_t bytes );
+         void ramtransfer( const name& from, const name& to, int64_t bytes, const std::string& memo );
 
          /**
           * Burn ram action, reduces owner's quota by bytes.
           *
           * @param owner - the ram owner account,
-          * @param bytes - the amount of ram to be burned in bytes.
+          * @param bytes - the amount of ram to be burned in bytes,
+          * @param memo - the memo string to accompany the transaction.
           */
          [[eosio::action]]
-         void ramburn( const name& owner, int64_t bytes );
+         void ramburn( const name& owner, int64_t bytes, const std::string& memo );
 
          /**
           * Refund action, this action is called after the delegation-period to claim all pending

--- a/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
+++ b/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
@@ -424,6 +424,17 @@ icon: @ICON_BASE_URL@/@RESOURCE_ICON_URI@
 
 Transfer {{bytes}} bytes of unused RAM from account {{from}} to account {{to}}.
 
+<h1 class="contract">ramburn</h1>
+
+---
+spec_version: "0.2.0"
+title: Burn RAM from Account
+summary: 'Burn unused RAM from {{nowrap from}}'
+icon: @ICON_BASE_URL@/@RESOURCE_ICON_URI@
+---
+
+Burn {{bytes}} bytes of unused RAM from account {{from}}.
+
 <h1 class="contract">sellrex</h1>
 
 ---

--- a/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
+++ b/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
@@ -433,13 +433,13 @@ Transfer {{bytes}} bytes of unused RAM from account {{from}} to account {{to}}.
 ---
 spec_version: "0.2.0"
 title: Burn RAM from Account
-summary: 'Burn unused RAM from {{nowrap from}}'
+summary: 'Burn unused RAM from {{nowrap owner}}'
 icon: @ICON_BASE_URL@/@RESOURCE_ICON_URI@
 ---
 
-Burn {{bytes}} bytes of unused RAM from account {{from}}.
+Burn {{bytes}} bytes of unused RAM from account {{owner}}.
 
-{{#if memo}}There is a memo attached to the transfer stating:
+{{#if memo}}There is a memo attached to the burn stating:
 {{memo}}
 {{/if}}
 

--- a/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
+++ b/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
@@ -424,6 +424,10 @@ icon: @ICON_BASE_URL@/@RESOURCE_ICON_URI@
 
 Transfer {{bytes}} bytes of unused RAM from account {{from}} to account {{to}}.
 
+{{#if memo}}There is a memo attached to the transfer stating:
+{{memo}}
+{{/if}}
+
 <h1 class="contract">ramburn</h1>
 
 ---
@@ -434,6 +438,10 @@ icon: @ICON_BASE_URL@/@RESOURCE_ICON_URI@
 ---
 
 Burn {{bytes}} bytes of unused RAM from account {{from}}.
+
+{{#if memo}}There is a memo attached to the transfer stating:
+{{memo}}
+{{/if}}
 
 <h1 class="contract">sellrex</h1>
 

--- a/contracts/eosio.system/src/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/src/delegate_bandwidth.cpp
@@ -132,6 +132,14 @@ namespace eosiosystem {
       require_recipient( to );
    }
 
+   /**
+    * This action will burn RAM bytes from owner account.
+    */
+   void system_contract::ramburn( const name& owner, int64_t bytes ) {
+      require_auth( owner );
+      ramtransfer( owner, null_account, bytes );
+   }
+
    void system_contract::reduce_ram( const name& owner, int64_t bytes ) {
       check( bytes > 0, "cannot reduce negative byte" );
       user_resources_table userres( get_self(), owner.value );

--- a/contracts/eosio.system/src/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/src/delegate_bandwidth.cpp
@@ -123,10 +123,11 @@ namespace eosiosystem {
 
    /**
     * This action will transfer RAM bytes from one account to another.
-   */
-   void system_contract::ramtransfer( const name& from, const name& to, int64_t bytes ) {
+    */
+   void system_contract::ramtransfer( const name& from, const name& to, int64_t bytes, const std::string& memo ) {
       require_auth( from );
       update_ram_supply();
+      check( memo.size() <= 256, "memo has more than 256 bytes" );
       reduce_ram( from, bytes );
       add_ram( to, bytes );
       require_recipient( to );
@@ -135,9 +136,9 @@ namespace eosiosystem {
    /**
     * This action will burn RAM bytes from owner account.
     */
-   void system_contract::ramburn( const name& owner, int64_t bytes ) {
+   void system_contract::ramburn( const name& owner, int64_t bytes, const std::string& memo ) {
       require_auth( owner );
-      ramtransfer( owner, null_account, bytes );
+      ramtransfer( owner, null_account, bytes, memo );
    }
 
    void system_contract::reduce_ram( const name& owner, int64_t bytes ) {

--- a/tests/eosio.system_ram_tests.cpp
+++ b/tests/eosio.system_ram_tests.cpp
@@ -38,9 +38,9 @@ BOOST_FIXTURE_TEST_CASE( ram_transfer, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( bob_before + 1000, bob_after );
 
    // RAM burn
-   BOOST_REQUIRE_EQUAL( success(), ramburn( alice, 1000, "burn RAM memo" ) );
+   BOOST_REQUIRE_EQUAL( success(), ramburn( alice, 3000, "burn RAM memo" ) );
    const uint64_t alice_after_burn = get_total_stake( alice )["ram_bytes"].as_uint64();
-   BOOST_REQUIRE_EQUAL( alice_before - 2000, alice_after_burn );
+   BOOST_REQUIRE_EQUAL( alice_before - 4000, alice_after_burn );
 
 } FC_LOG_AND_RETHROW()
 

--- a/tests/eosio.system_ram_tests.cpp
+++ b/tests/eosio.system_ram_tests.cpp
@@ -37,6 +37,11 @@ BOOST_FIXTURE_TEST_CASE( ram_transfer, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( alice_before - 1000, alice_after );
    BOOST_REQUIRE_EQUAL( bob_before + 1000, bob_after );
 
+   // RAM burn
+   BOOST_REQUIRE_EQUAL( success(), ramburn( alice, 1000 ) );
+   const uint64_t alice_after_burn = get_total_stake( alice )["ram_bytes"].as_uint64();
+   BOOST_REQUIRE_EQUAL( alice_before - 2000, alice_after_burn );
+
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/eosio.system_ram_tests.cpp
+++ b/tests/eosio.system_ram_tests.cpp
@@ -29,7 +29,7 @@ BOOST_FIXTURE_TEST_CASE( ram_transfer, eosio_system_tester ) try {
    const uint64_t alice_before = get_total_stake( alice )["ram_bytes"].as_uint64();
    const uint64_t bob_before = get_total_stake( bob )["ram_bytes"].as_uint64();
 
-   BOOST_REQUIRE_EQUAL( success(), ramtransfer( alice, bob, 1000 ) );
+   BOOST_REQUIRE_EQUAL( success(), ramtransfer( alice, bob, 1000, "" ) );
 
    const uint64_t alice_after = get_total_stake( alice )["ram_bytes"].as_uint64();
    const uint64_t bob_after = get_total_stake( bob )["ram_bytes"].as_uint64();
@@ -38,7 +38,7 @@ BOOST_FIXTURE_TEST_CASE( ram_transfer, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL( bob_before + 1000, bob_after );
 
    // RAM burn
-   BOOST_REQUIRE_EQUAL( success(), ramburn( alice, 1000 ) );
+   BOOST_REQUIRE_EQUAL( success(), ramburn( alice, 1000, "burn RAM memo" ) );
    const uint64_t alice_after_burn = get_total_stake( alice )["ram_bytes"].as_uint64();
    BOOST_REQUIRE_EQUAL( alice_before - 2000, alice_after_burn );
 

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -253,18 +253,18 @@ public:
       return buyram( account_name(payer), account_name(receiver), eosin );
    }
 
-   action_result ramtransfer( const account_name& from, const account_name& to, uint32_t bytes ) {
-      return push_action( from, "ramtransfer"_n, mvo()( "from",from)("to",to)("bytes",bytes) );
+   action_result ramtransfer( const account_name& from, const account_name& to, uint32_t bytes, const string& memo ) {
+      return push_action( from, "ramtransfer"_n, mvo()( "from",from)("to",to)("bytes",bytes)(("memo",memo)) );
    }
-   action_result ramtransfer( std::string_view from, std::string_view to, uint32_t bytes ) {
-      return ramtransfer( account_name(from), account_name(to), bytes );
+   action_result ramtransfer( std::string_view from, std::string_view to, uint32_t bytes, const string& memo ) {
+      return ramtransfer( account_name(from), account_name(to), bytes, memo );
    }
 
-   action_result ramburn( const account_name& owner, uint32_t bytes ) {
-      return push_action( owner, "ramburn"_n, mvo()( "owner",owner)("bytes",bytes) );
+   action_result ramburn( const account_name& owner, uint32_t bytes, const string& memo ) {
+      return push_action( owner, "ramburn"_n, mvo()( "owner",owner)("bytes",bytes)("memo",memo) );
    }
-   action_result ramburn( std::string_view owner, uint32_t bytes ) {
-      return ramburn( account_name(owner), bytes );
+   action_result ramburn( std::string_view owner, uint32_t bytes, const string& memo ) {
+      return ramburn( account_name(owner), bytes, memo );
    }
 
    action_result buyrambytes( const account_name& payer, account_name receiver, uint32_t numbytes ) {

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -253,17 +253,17 @@ public:
       return buyram( account_name(payer), account_name(receiver), eosin );
    }
 
-   action_result ramtransfer( const account_name& from, const account_name& to, uint32_t bytes, const string& memo ) {
-      return push_action( from, "ramtransfer"_n, mvo()( "from",from)("to",to)("bytes",bytes)(("memo",memo)) );
+   action_result ramtransfer( const account_name& from, const account_name& to, uint32_t bytes, const std::string& memo ) {
+      return push_action( from, "ramtransfer"_n, mvo()( "from",from)("to",to)("bytes",bytes)("memo",memo));
    }
-   action_result ramtransfer( std::string_view from, std::string_view to, uint32_t bytes, const string& memo ) {
+   action_result ramtransfer( std::string_view from, std::string_view to, uint32_t bytes, const std::string& memo ) {
       return ramtransfer( account_name(from), account_name(to), bytes, memo );
    }
 
-   action_result ramburn( const account_name& owner, uint32_t bytes, const string& memo ) {
+   action_result ramburn( const account_name& owner, uint32_t bytes, const std::string& memo ) {
       return push_action( owner, "ramburn"_n, mvo()( "owner",owner)("bytes",bytes)("memo",memo) );
    }
-   action_result ramburn( std::string_view owner, uint32_t bytes, const string& memo ) {
+   action_result ramburn( std::string_view owner, uint32_t bytes, const std::string& memo ) {
       return ramburn( account_name(owner), bytes, memo );
    }
 

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -260,7 +260,7 @@ public:
       return ramtransfer( account_name(from), account_name(to), bytes );
    }
 
-   action_result ramburn( const account_name& owner, const account_name& to, uint32_t bytes ) {
+   action_result ramburn( const account_name& owner, uint32_t bytes ) {
       return push_action( owner, "ramburn"_n, mvo()( "owner",owner)("bytes",bytes) );
    }
    action_result ramburn( std::string_view owner, uint32_t bytes ) {

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -260,6 +260,13 @@ public:
       return ramtransfer( account_name(from), account_name(to), bytes );
    }
 
+   action_result ramburn( const account_name& owner, const account_name& to, uint32_t bytes ) {
+      return push_action( owner, "ramburn"_n, mvo()( "owner",owner)("bytes",bytes) );
+   }
+   action_result ramburn( std::string_view owner, uint32_t bytes ) {
+      return ramburn( account_name(owner), bytes );
+   }
+
    action_result buyrambytes( const account_name& payer, account_name receiver, uint32_t numbytes ) {
       return push_action( payer, "buyrambytes"_n, mvo()( "payer",payer)("receiver",receiver)("bytes",numbytes) );
    }


### PR DESCRIPTION
## Change Description

New RAM system contract action to burn RAM from owner account.

### Preconditions
- Same conditions as `ramtransfer` action https://github.com/eosnetworkfoundation/eos-system-contracts/pull/102
- Burned RAM is transferred to `eosio.null` account
- Should have no impact on RAM Bancor market, RAM supply should remain unchanged

## API Changes

#### ACTION: `ramburn`

- `owner {name}`
- `bytes {int64}`
- `memo {string}`

## Documentation Additions
- https://github.com/eosnetworkfoundation/eos-system-contracts/pull/102