### PR TITLE
updated CDT and Leap version in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5)
 project(eosio_contracts)
 
 set(VERSION_MAJOR 3)
-set(VERSION_MINOR 3)
+set(VERSION_MINOR 2)
 set(VERSION_PATCH 0)
 set(VERSION_SUFFIX dev)
 
@@ -44,6 +44,13 @@ ExternalProject_Add(
   TEST_COMMAND ""
   INSTALL_COMMAND ""
   BUILD_ALWAYS 1)
+
+if(APPLE)
+  set(OPENSSL_ROOT "/usr/local/opt/openssl")
+elseif(UNIX)
+  set(OPENSSL_ROOT "/usr/include/openssl")
+endif()
+set(SECP256K1_ROOT "/usr/local")
 
 if(APPLE)
   set(OPENSSL_ROOT "/usr/local/opt/openssl")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5)
 project(eosio_contracts)
 
 set(VERSION_MAJOR 3)
-set(VERSION_MINOR 2)
+set(VERSION_MINOR 3)
 set(VERSION_PATCH 0)
 set(VERSION_SUFFIX dev)
 
@@ -44,20 +44,6 @@ ExternalProject_Add(
   TEST_COMMAND ""
   INSTALL_COMMAND ""
   BUILD_ALWAYS 1)
-
-if(APPLE)
-  set(OPENSSL_ROOT "/usr/local/opt/openssl")
-elseif(UNIX)
-  set(OPENSSL_ROOT "/usr/include/openssl")
-endif()
-set(SECP256K1_ROOT "/usr/local")
-
-if(APPLE)
-  set(OPENSSL_ROOT "/usr/local/opt/openssl")
-elseif(UNIX)
-  set(OPENSSL_ROOT "/usr/include/openssl")
-endif()
-set(SECP256K1_ROOT "/usr/local")
 
 option(BUILD_TESTS "Build unit tests" OFF)
 

--- a/contracts/CMakeLists.txt
+++ b/contracts/CMakeLists.txt
@@ -8,7 +8,7 @@ option(SYSTEM_CONFIGURABLE_WASM_LIMITS
 option(SYSTEM_BLOCKCHAIN_PARAMETERS
        "Enables use of the host functions activated by the BLOCKCHAIN_PARAMETERS protocol feature" ON)
 
-find_package(cdt)
+find_package(cdt REQUIRED)
 
 set(CDT_VERSION_MIN "3.0")
 set(CDT_VERSION_SOFT_MAX "4.0")

--- a/contracts/CMakeLists.txt
+++ b/contracts/CMakeLists.txt
@@ -8,10 +8,10 @@ option(SYSTEM_CONFIGURABLE_WASM_LIMITS
 option(SYSTEM_BLOCKCHAIN_PARAMETERS
        "Enables use of the host functions activated by the BLOCKCHAIN_PARAMETERS protocol feature" ON)
 
-find_package(cdt REQUIRED)
+find_package(cdt)
 
 set(CDT_VERSION_MIN "3.0")
-set(CDT_VERSION_SOFT_MAX "3.0")
+set(CDT_VERSION_SOFT_MAX "4.0")
 # set(CDT_VERSION_HARD_MAX "")
 
 # Check the version of CDT
@@ -31,7 +31,7 @@ if(SYSTEM_ENABLE_CDT_VERSION_CHECK)
       FATAL_ERROR
         "Found CDT version ${CDT_VERSION} but it does not satisfy version requirements: ${VERSION_MATCH_ERROR_MSG}\nPlease use CDT version ${CDT_VERSION_SOFT_MAX}.x"
     )
-  endif()
+  endif(VERSION_OUTPUT STREQUAL "MATCH")
 endif()
 
 set(ICON_BASE_URL "https://raw.githubusercontent.com/eosnetworkfoundation/eos-system-contracts/main/contracts/icons")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ set(EOSIO_VERSION_MIN "3.1")
 set(EOSIO_VERSION_SOFT_MAX "5.0")
 # set(EOSIO_VERSION_HARD_MAX "")
 
-find_package(leap)
+find_package(leap REQUIRED)
 
 # Check the version of Leap
 if(SYSTEM_ENABLE_LEAP_VERSION_CHECK)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.5)
 
 set(EOSIO_VERSION_MIN "3.1")
-set(EOSIO_VERSION_SOFT_MAX "4.1")
+set(EOSIO_VERSION_SOFT_MAX "5.0")
 # set(EOSIO_VERSION_HARD_MAX "")
 
-find_package(leap REQUIRED)
+find_package(leap)
 
 # Check the version of Leap
 if(SYSTEM_ENABLE_LEAP_VERSION_CHECK)
@@ -23,7 +23,7 @@ if(SYSTEM_ENABLE_LEAP_VERSION_CHECK)
       FATAL_ERROR
         "Found Leap version ${EOSIO_VERSION} but it does not satisfy version requirements: ${VERSION_MATCH_ERROR_MSG}\nPlease use Leap version ${EOSIO_VERSION_SOFT_MAX}.x"
     )
-  endif()
+  endif(VERSION_OUTPUT STREQUAL "MATCH")
 endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/contracts.hpp.in ${CMAKE_CURRENT_BINARY_DIR}/contracts.hpp)


### PR DESCRIPTION
Merging in updates from reference contracts
- Remove platform specific openssl 
- Use latest CDT version 
- User latest Leap version 

resolves #77 