### PR TITLE
New ram_actions to transfer ram between accounts

### DIFF
--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -545,6 +545,29 @@ namespace eosiosystem {
       asset stake_change;
    };
 
+   struct action_return_sellram {
+      name account;
+      asset quantity;
+      int64_t bytes_sold;
+      int64_t ram_bytes;
+   };
+
+   struct action_return_buyram {
+      name payer;
+      name receiver;
+      asset quantity;
+      int64_t bytes_purchased;
+      int64_t ram_bytes;
+   };
+
+   struct action_return_ramtransfer {
+      name from;
+      name to;
+      int64_t bytes;
+      int64_t from_ram_bytes;
+      int64_t to_ram_bytes;
+   };
+
    struct powerup_config_resource {
       std::optional<int64_t>        current_weight_ratio;   // Immediately set weight_ratio to this amount. 1x = 10^15. 0.01x = 10^13.
                                                             //    Do not specify to preserve the existing setting or use the default;
@@ -1097,7 +1120,7 @@ namespace eosiosystem {
           * @param quant - the quantity of tokens to buy ram with.
           */
          [[eosio::action]]
-         void buyram( const name& payer, const name& receiver, const asset& quant );
+         action_return_buyram buyram( const name& payer, const name& receiver, const asset& quant );
 
          /**
           * Buy a specific amount of ram bytes action. Increases receiver's ram in quantity of bytes provided.
@@ -1108,7 +1131,30 @@ namespace eosiosystem {
           * @param bytes - the quantity of ram to buy specified in bytes.
           */
          [[eosio::action]]
-         void buyrambytes( const name& payer, const name& receiver, uint32_t bytes );
+         action_return_buyram buyrambytes( const name& payer, const name& receiver, uint32_t bytes );
+
+         /**
+          * The buyramself action is designed to enhance the permission security by allowing an account to purchase RAM exclusively for itself.
+          * This action prevents the potential risk associated with standard actions like buyram and buyrambytes,
+          * which can transfer EOS tokens out of the account, acting as a proxy for eosio.token::transfer.
+          *
+          * @param account - the ram buyer and receiver,
+          * @param quant - the quantity of tokens to buy ram with.
+          */
+         [[eosio::action]]
+         action_return_buyram buyramself( const name& account, const asset& quant );
+
+         /**
+          * Logging for buyram & buyrambytes action
+          *
+          * @param payer - the ram buyer,
+          * @param receiver - the ram receiver,
+          * @param quantity - the quantity of tokens to buy ram with.
+          * @param bytes - the quantity of ram to buy specified in bytes.
+          * @param ram_bytes - the ram bytes held by receiver after the action.
+          */
+         [[eosio::action]]
+         void logbuyram( const name& payer, const name& receiver, const asset& quantity, int64_t bytes, int64_t ram_bytes );
 
          /**
           * Sell ram action, reduces quota by bytes and then performs an inline transfer of tokens
@@ -1118,7 +1164,49 @@ namespace eosiosystem {
           * @param bytes - the amount of ram to sell in bytes.
           */
          [[eosio::action]]
-         void sellram( const name& account, int64_t bytes );
+         action_return_sellram sellram( const name& account, int64_t bytes );
+
+         /**
+          * Logging for sellram action
+          *
+          * @param account - the ram seller,
+          * @param quantity - the quantity of tokens to sell ram with.
+          * @param bytes - the quantity of ram to sell specified in bytes.
+          * @param ram_bytes - the ram bytes held by account after the action.
+          */
+         [[eosio::action]]
+         void logsellram( const name& account, const asset& quantity, int64_t bytes, int64_t ram_bytes );
+
+         /**
+          * Transfer ram action, reduces sender's quota by bytes and increase receiver's quota by bytes.
+          *
+          * @param from - the ram sender account,
+          * @param to - the ram receiver account,
+          * @param bytes - the amount of ram to transfer in bytes,
+          * @param memo - the memo string to accompany the transaction.
+          */
+         [[eosio::action]]
+         action_return_ramtransfer ramtransfer( const name& from, const name& to, int64_t bytes, const std::string& memo );
+
+         /**
+          * Burn ram action, reduces owner's quota by bytes.
+          *
+          * @param owner - the ram owner account,
+          * @param bytes - the amount of ram to be burned in bytes,
+          * @param memo - the memo string to accompany the transaction.
+          */
+         [[eosio::action]]
+         action_return_ramtransfer ramburn( const name& owner, int64_t bytes, const std::string& memo );
+
+         /**
+          * Logging for ram changes
+          *
+          * @param owner - the ram owner account,
+          * @param bytes - the bytes balance change,
+          * @param ram_bytes - the ram bytes held by owner after the action.
+          */
+         [[eosio::action]]
+         void logramchange( const name& owner, int64_t bytes, int64_t ram_bytes );
 
          /**
           * Refund action, this action is called after the delegation-period to claim all pending
@@ -1417,7 +1505,12 @@ namespace eosiosystem {
          using undelegatebw_action = eosio::action_wrapper<"undelegatebw"_n, &system_contract::undelegatebw>;
          using buyram_action = eosio::action_wrapper<"buyram"_n, &system_contract::buyram>;
          using buyrambytes_action = eosio::action_wrapper<"buyrambytes"_n, &system_contract::buyrambytes>;
+         using logbuyram_action = eosio::action_wrapper<"logbuyram"_n, &system_contract::logbuyram>;
          using sellram_action = eosio::action_wrapper<"sellram"_n, &system_contract::sellram>;
+         using logsellram_action = eosio::action_wrapper<"logsellram"_n, &system_contract::logsellram>;
+         using ramtransfer_action = eosio::action_wrapper<"ramtransfer"_n, &system_contract::ramtransfer>;
+         using ramburn_action = eosio::action_wrapper<"ramburn"_n, &system_contract::ramburn>;
+         using logramchange_action = eosio::action_wrapper<"logramchange"_n, &system_contract::logramchange>;
          using refund_action = eosio::action_wrapper<"refund"_n, &system_contract::refund>;
          using regproducer_action = eosio::action_wrapper<"regproducer"_n, &system_contract::regproducer>;
          using regproducer2_action = eosio::action_wrapper<"regproducer2"_n, &system_contract::regproducer2>;
@@ -1496,6 +1589,9 @@ namespace eosiosystem {
          void changebw( name from, const name& receiver,
                         const asset& stake_net_quantity, const asset& stake_cpu_quantity, bool transfer );
          void update_voting_power( const name& voter, const asset& total_update );
+         void set_resource_ram_bytes_limits( const name& owner );
+         int64_t reduce_ram( const name& owner, int64_t bytes );
+         int64_t add_ram( const name& owner, int64_t bytes );
 
          // defined in voting.cpp
          void register_producer( const name& producer, const eosio::block_signing_authority& producer_authority, const std::string& url, uint16_t location );

--- a/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
+++ b/contracts/eosio.system/ricardian/eosio.system.contracts.md.in
@@ -59,6 +59,17 @@ icon: @ICON_BASE_URL@/@RESOURCE_ICON_URI@
 
 {{payer}} buys RAM on behalf of {{receiver}} by paying {{quant}}. This transaction will incur a 0.5% fee out of {{quant}} and the amount of RAM delivered will depend on market rates.
 
+<h1 class="contract">buyramself</h1>
+
+---
+spec_version: "0.2.0"
+title: Buy RAM self
+summary: '{{nowrap account}} buys RAM to self by paying {{nowrap quant}}'
+icon: @ICON_BASE_URL@/@RESOURCE_ICON_URI@
+---
+
+{{account}} buys RAM to self by paying {{quant}}. This transaction will incur a 0.5% fee out of {{quant}} and the amount of RAM delivered will depend on market rates.
+
 <h1 class="contract">buyrambytes</h1>
 
 ---
@@ -412,6 +423,36 @@ icon: @ICON_BASE_URL@/@RESOURCE_ICON_URI@
 ---
 
 Sell {{bytes}} bytes of unused RAM from account {{account}} at market price. This transaction will incur a 0.5% fee on the proceeds which depend on market rates.
+
+<h1 class="contract">ramtransfer</h1>
+
+---
+spec_version: "0.2.0"
+title: Transfer RAM from Account
+summary: 'Transfer unused RAM from {{nowrap from}} to {{nowrap to}}'
+icon: @ICON_BASE_URL@/@RESOURCE_ICON_URI@
+---
+
+Transfer {{bytes}} bytes of unused RAM from account {{from}} to account {{to}}.
+
+{{#if memo}}There is a memo attached to the transfer stating:
+{{memo}}
+{{/if}}
+
+<h1 class="contract">ramburn</h1>
+
+---
+spec_version: "0.2.0"
+title: Burn RAM from Account
+summary: 'Burn unused RAM from {{nowrap owner}}'
+icon: @ICON_BASE_URL@/@RESOURCE_ICON_URI@
+---
+
+Burn {{bytes}} bytes of unused RAM from account {{owner}}.
+
+{{#if memo}}There is a memo attached to the burn stating:
+{{memo}}
+{{/if}}
 
 <h1 class="contract">sellrex</h1>
 

--- a/contracts/eosio.system/src/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/src/delegate_bandwidth.cpp
@@ -22,15 +22,21 @@ namespace eosiosystem {
    /**
     *  This action will buy an exact amount of ram and bill the payer the current market price.
     */
-   void system_contract::buyrambytes( const name& payer, const name& receiver, uint32_t bytes ) {
+   action_return_buyram system_contract::buyrambytes( const name& payer, const name& receiver, uint32_t bytes ) {
       auto itr = _rammarket.find(ramcore_symbol.raw());
       const int64_t ram_reserve   = itr->base.balance.amount;
       const int64_t eos_reserve   = itr->quote.balance.amount;
       const int64_t cost          = exchange_state::get_bancor_input( ram_reserve, eos_reserve, bytes );
       const int64_t cost_plus_fee = cost / double(0.995);
-      buyram( payer, receiver, asset{ cost_plus_fee, core_symbol() } );
+      return buyram( payer, receiver, asset{ cost_plus_fee, core_symbol() } );
    }
 
+   /**
+    * Buy self ram action, ram can only be purchased to itself.
+    */
+   action_return_buyram system_contract::buyramself( const name& account, const asset& quant ) {
+      return buyram( account, account, quant );
+   }
 
    /**
     *  When buying ram the payer irreversibly transfers quant to system contract and only
@@ -40,10 +46,12 @@ namespace eosiosystem {
     *  RAM is a scarce resource whose supply is defined by global properties max_ram_size. RAM is
     *  priced using the bancor algorithm such that price-per-byte with a constant reserve ratio of 100:1.
     */
-   void system_contract::buyram( const name& payer, const name& receiver, const asset& quant )
+   action_return_buyram system_contract::buyram( const name& payer, const name& receiver, const asset& quant )
    {
       require_auth( payer );
       update_ram_supply();
+      require_recipient(payer);
+      require_recipient(receiver);
 
       check( quant.symbol == core_symbol(), "must buy ram with core token" );
       check( quant.amount > 0, "must purchase a positive amount" );
@@ -79,27 +87,20 @@ namespace eosiosystem {
       _gstate.total_ram_bytes_reserved += uint64_t(bytes_out);
       _gstate.total_ram_stake          += quant_after_fee.amount;
 
-      user_resources_table  userres( get_self(), receiver.value );
-      auto res_itr = userres.find( receiver.value );
-      if( res_itr ==  userres.end() ) {
-         res_itr = userres.emplace( receiver, [&]( auto& res ) {
-               res.owner = receiver;
-               res.net_weight = asset( 0, core_symbol() );
-               res.cpu_weight = asset( 0, core_symbol() );
-               res.ram_bytes = bytes_out;
-            });
-      } else {
-         userres.modify( res_itr, receiver, [&]( auto& res ) {
-               res.ram_bytes += bytes_out;
-            });
-      }
+      const int64_t ram_bytes = add_ram( receiver, bytes_out );
 
-      auto voter_itr = _voters.find( res_itr->owner.value );
-      if( voter_itr == _voters.end() || !has_field( voter_itr->flags1, voter_info::flags1_fields::ram_managed ) ) {
-         int64_t ram_bytes, net, cpu;
-         get_resource_limits( res_itr->owner, ram_bytes, net, cpu );
-         set_resource_limits( res_itr->owner, res_itr->ram_bytes + ram_gift_bytes, net, cpu );
-      }
+      // logging
+      system_contract::logbuyram_action logbuyram_act{ get_self(), { {get_self(), active_permission} } };
+      logbuyram_act.send( payer, receiver, quant, bytes_out, ram_bytes );
+
+      // action return value
+      return action_return_buyram{ payer, receiver, quant, bytes_out, ram_bytes };
+   }
+
+   void system_contract::logbuyram( const name& payer, const name& receiver, const asset& quantity, int64_t bytes, int64_t ram_bytes ) {
+      require_auth( get_self() );
+      require_recipient(payer);
+      require_recipient(receiver);
    }
 
   /**
@@ -108,16 +109,11 @@ namespace eosiosystem {
     *  tomorrow. Overall this will result in the market balancing the supply and demand
     *  for RAM over time.
     */
-   void system_contract::sellram( const name& account, int64_t bytes ) {
+   action_return_sellram system_contract::sellram( const name& account, int64_t bytes ) {
       require_auth( account );
       update_ram_supply();
-
-      check( bytes > 0, "cannot sell negative byte" );
-
-      user_resources_table  userres( get_self(), account.value );
-      auto res_itr = userres.find( account.value );
-      check( res_itr != userres.end(), "no resource row" );
-      check( res_itr->ram_bytes >= bytes, "insufficient quota" );
+      require_recipient(account);
+      const int64_t ram_bytes = reduce_ram(account, bytes);
 
       asset tokens_out;
       auto itr = _rammarket.find(ramcore_symbol.raw());
@@ -134,17 +130,6 @@ namespace eosiosystem {
       //// this shouldn't happen, but just in case it does we should prevent it
       check( _gstate.total_ram_stake >= 0, "error, attempt to unstake more tokens than previously staked" );
 
-      userres.modify( res_itr, account, [&]( auto& res ) {
-          res.ram_bytes -= bytes;
-      });
-
-      auto voter_itr = _voters.find( res_itr->owner.value );
-      if( voter_itr == _voters.end() || !has_field( voter_itr->flags1, voter_info::flags1_fields::ram_managed ) ) {
-         int64_t ram_bytes, net, cpu;
-         get_resource_limits( res_itr->owner, ram_bytes, net, cpu );
-         set_resource_limits( res_itr->owner, res_itr->ram_bytes + ram_gift_bytes, net, cpu );
-      }
-
       {
          token::transfer_action transfer_act{ token_account, { {ram_account, active_permission}, {account, active_permission} } };
          transfer_act.send( ram_account, account, asset(tokens_out), "sell ram" );
@@ -155,6 +140,104 @@ namespace eosiosystem {
          token::transfer_action transfer_act{ token_account, { {account, active_permission} } };
          transfer_act.send( account, ramfee_account, asset(fee, core_symbol()), "sell ram fee" );
          channel_to_rex( ramfee_account, asset(fee, core_symbol() ));
+      }
+
+      // logging
+      system_contract::logsellram_action logsellram_act{ get_self(), { {get_self(), active_permission} } };
+      logsellram_act.send( account, tokens_out, bytes, ram_bytes );
+
+      // action return value
+      return action_return_sellram{ account, tokens_out, bytes, ram_bytes };
+   }
+
+   void system_contract::logsellram( const name& account, const asset& quantity, int64_t bytes, int64_t ram_bytes ) {
+      require_auth( get_self() );
+      require_recipient(account);
+   }
+
+   /**
+    * This action will transfer RAM bytes from one account to another.
+    */
+   action_return_ramtransfer system_contract::ramtransfer( const name& from, const name& to, int64_t bytes, const std::string& memo ) {
+      require_auth( from );
+      update_ram_supply();
+      check( memo.size() <= 256, "memo has more than 256 bytes" );
+      const int64_t from_ram_bytes = reduce_ram( from, bytes );
+      const int64_t to_ram_bytes = add_ram( to, bytes );
+      require_recipient( from );
+      require_recipient( to );
+
+      // action return value
+      return action_return_ramtransfer{ from, to, bytes, from_ram_bytes, to_ram_bytes };
+   }
+
+   /**
+    * This action will burn RAM bytes from owner account.
+    */
+   action_return_ramtransfer system_contract::ramburn( const name& owner, int64_t bytes, const std::string& memo ) {
+      require_auth( owner );
+      return ramtransfer( owner, null_account, bytes, memo );
+   }
+
+   [[eosio::action]]
+   void system_contract::logramchange( const name& owner, int64_t bytes, int64_t ram_bytes )
+   {
+      require_auth( get_self() );
+      require_recipient( owner );
+   }
+
+   int64_t system_contract::reduce_ram( const name& owner, int64_t bytes ) {
+      check( bytes > 0, "cannot reduce negative byte" );
+      user_resources_table userres( get_self(), owner.value );
+      auto res_itr = userres.find( owner.value );
+      check( res_itr != userres.end(), "no resource row" );
+      check( res_itr->ram_bytes >= bytes, "insufficient quota" );
+
+      userres.modify( res_itr, same_payer, [&]( auto& res ) {
+          res.ram_bytes -= bytes;
+      });
+      set_resource_ram_bytes_limits( owner );
+
+      // logging
+      system_contract::logramchange_action logramchange_act{ get_self(), { {get_self(), active_permission} }};
+      logramchange_act.send( owner, -bytes, res_itr->ram_bytes );
+      return res_itr->ram_bytes;
+   }
+
+   int64_t system_contract::add_ram( const name& owner, int64_t bytes ) {
+      check( bytes > 0, "cannot add negative byte" );
+      check( is_account(owner), "owner=" + owner.to_string() + " account does not exist");
+      user_resources_table userres( get_self(), owner.value );
+      auto res_itr = userres.find( owner.value );
+      if ( res_itr == userres.end() ) {
+         userres.emplace( owner, [&]( auto& res ) {
+            res.owner = owner;
+            res.net_weight = asset( 0, core_symbol() );
+            res.cpu_weight = asset( 0, core_symbol() );
+            res.ram_bytes = bytes;
+         });
+      } else {
+         userres.modify( res_itr, same_payer, [&]( auto& res ) {
+            res.ram_bytes += bytes;
+         });
+      }
+      set_resource_ram_bytes_limits( owner );
+
+      // logging
+      system_contract::logramchange_action logramchange_act{ get_self(), { {get_self(), active_permission} } };
+      logramchange_act.send( owner, bytes, res_itr->ram_bytes );
+      return res_itr->ram_bytes;
+   }
+
+   void system_contract::set_resource_ram_bytes_limits( const name& owner ) {
+      user_resources_table userres( get_self(), owner.value );
+      auto res_itr = userres.find( owner.value );
+
+      auto voter_itr = _voters.find( owner.value );
+      if ( voter_itr == _voters.end() || !has_field( voter_itr->flags1, voter_info::flags1_fields::ram_managed ) ) {
+         int64_t ram_bytes, net, cpu;
+         get_resource_limits( owner, ram_bytes, net, cpu );
+         set_resource_limits( owner, res_itr->ram_bytes + ram_gift_bytes, net, cpu );
       }
    }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 set(EOSIO_VERSION_MIN "3.1")
-set(EOSIO_VERSION_SOFT_MAX "4.1")
+set(EOSIO_VERSION_SOFT_MAX "5.0")
 # set(EOSIO_VERSION_HARD_MAX "")
 
 find_package(leap REQUIRED)

--- a/tests/eosio.system_ram_tests.cpp
+++ b/tests/eosio.system_ram_tests.cpp
@@ -1,0 +1,192 @@
+#include <boost/test/unit_test.hpp>
+#include <eosio/chain/contract_table_objects.hpp>
+#include <eosio/chain/global_property_object.hpp>
+#include <eosio/chain/resource_limits.hpp>
+#include <eosio/chain/wast_to_wasm.hpp>
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+#include <fc/log/logger.hpp>
+#include <eosio/chain/exceptions.hpp>
+
+#include "eosio.system_tester.hpp"
+
+using namespace eosio_system;
+
+BOOST_AUTO_TEST_SUITE(eosio_system_ram_tests);
+
+// ramtransfer
+BOOST_FIXTURE_TEST_CASE( ram_transfer, eosio_system_tester ) try {
+   const std::vector<account_name> accounts = { "alice"_n, "bob"_n };
+   create_accounts_with_resources( accounts );
+   const account_name alice = accounts[0];
+   const account_name bob = accounts[1];
+
+   transfer( config::system_account_name, alice, core_sym::from_string("100.0000"), config::system_account_name );
+   transfer( config::system_account_name, bob, core_sym::from_string("100.0000"), config::system_account_name );
+   BOOST_REQUIRE_EQUAL( success(), buyrambytes( alice, alice, 10000 ) );
+   BOOST_REQUIRE_EQUAL( success(), buyrambytes( bob, bob, 10000 ) );
+
+   const uint64_t alice_before = get_total_stake( alice )["ram_bytes"].as_uint64();
+   const uint64_t bob_before = get_total_stake( bob )["ram_bytes"].as_uint64();
+
+   ramtransfer( alice, bob, 1000, "" );
+
+   const uint64_t alice_after = get_total_stake( alice )["ram_bytes"].as_uint64();
+   const uint64_t bob_after = get_total_stake( bob )["ram_bytes"].as_uint64();
+
+   BOOST_REQUIRE_EQUAL( alice_before - 1000, alice_after );
+   BOOST_REQUIRE_EQUAL( bob_before + 1000, bob_after );
+
+   /*
+    * The from_ram_bytes is alice's ram byte total
+    * The to_ram_bytes is bob's ram byte total
+    * Accounts start with 8,000 ram bytes
+    *     this is via create_accounts_with_resources()
+    * Next buyram on each account purchases 10,000 additional ram bytes
+    *     minus fees of 17 ram bytes
+    *
+    * Before ram transfer the totals for each account are 17,983 ram bytes
+    * After transfer of 1,000 bytes
+    *      bob and alice respective totals are 18,983 and 16,983
+    * After the validate ram transfer below of 1 ram byte
+    *      bob and alices respective totals are 18,984 and 16,982
+    */
+   const char* expected_return_data = R"=====(
+{
+   "from": "alice",
+   "to": "bob",
+   "bytes": 1,
+   "from_ram_bytes": 16982,
+   "to_ram_bytes": 18984
+}
+)=====";
+   validate_ramtransfer_return(alice, bob, 1, "",
+                               "action_return_ramtransfer", expected_return_data );
+
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE( buy_sell_ram_validate, eosio_system_tester ) try {
+   const std::vector<account_name> accounts = { "alice"_n, "bob"_n };
+   create_accounts_with_resources( accounts );
+   const account_name alice = accounts[0];
+   const account_name bob = accounts[1];
+
+   transfer( config::system_account_name, alice, core_sym::from_string("100.0000"), config::system_account_name );
+   transfer( config::system_account_name, bob, core_sym::from_string("100.0000"), config::system_account_name );
+   BOOST_REQUIRE_EQUAL( success(), buyrambytes( bob, bob, 10000 ) );
+
+   const char* expected_buyrambytes_return_data = R"=====(
+{
+   "payer": "alice",
+   "receiver": "alice",
+   "quantity": "0.1462 TST",
+   "bytes_purchased": 9991,
+   "ram_bytes": 17983
+}
+)=====";
+   validate_buyrambytes_return(alice, alice, 10000,
+                               "action_return_buyram", expected_buyrambytes_return_data );
+
+   const char* expected_sellram_return_data = R"=====(
+{
+   "account": "alice",
+   "quantity": "0.1455 TST",
+   "bytes_sold": 10000,
+   "ram_bytes": 7983
+}
+)=====";
+   validate_sellram_return(alice, 10000,
+                        "action_return_sellram", expected_sellram_return_data );
+
+   const char* expected_buyram_return_data = R"=====(
+{
+   "payer": "bob",
+   "receiver": "alice",
+   "quantity": "2.0000 TST",
+   "bytes_purchased": 136750,
+   "ram_bytes": 144733
+}
+)=====";
+   validate_buyram_return(bob, alice, core_sym::from_string("2.0000"),
+                          "action_return_buyram", expected_buyram_return_data );
+} FC_LOG_AND_RETHROW()
+
+// ramburn
+BOOST_FIXTURE_TEST_CASE( ram_burn, eosio_system_tester ) try {
+   const std::vector<account_name> accounts = { "alice"_n, "bob"_n };
+   create_accounts_with_resources( accounts );
+   const account_name alice = accounts[0];
+   const account_name bob = accounts[1];
+   const account_name null_account = "eosio.null"_n;
+
+   transfer( config::system_account_name, alice, core_sym::from_string("100.0000"), config::system_account_name );
+   transfer( config::system_account_name, bob, core_sym::from_string("100.0000"), config::system_account_name );
+   BOOST_REQUIRE_EQUAL( success(), buyrambytes( alice, alice, 10000 ) );
+   BOOST_REQUIRE_EQUAL( success(), buyrambytes( alice, null_account, 10000 ) );
+
+   const char* expected_buyramself_return_data = R"=====(
+{
+   "payer": "bob",
+   "receiver": "bob",
+   "quantity": "10.0000 TST",
+   "bytes_purchased": 683747,
+   "ram_bytes": 691739
+}
+)=====";
+   validate_buyramself_return(bob, core_sym::from_string("10.0000"),
+                              "action_return_buyram", expected_buyramself_return_data ) ;
+
+   const uint64_t null_before_burn = get_total_stake( null_account )["ram_bytes"].as_uint64();
+   const uint64_t alice_before_burn = get_total_stake( alice )["ram_bytes"].as_uint64();
+
+   // burn action
+   BOOST_REQUIRE_EQUAL( success(), ramburn( alice, 3000, "burn RAM memo" ) );
+   const uint64_t alice_after_burn = get_total_stake( alice )["ram_bytes"].as_uint64();
+   const uint64_t null_after_burn = get_total_stake( null_account )["ram_bytes"].as_uint64();
+   BOOST_REQUIRE_EQUAL( alice_before_burn - 3000, alice_after_burn );
+   BOOST_REQUIRE_EQUAL( null_before_burn + 3000, null_after_burn );
+
+   const char* expected_ramburn_return_data = R"=====(
+{
+   "from": "bob",
+   "to": "eosio.null",
+   "bytes": 1,
+   "from_ram_bytes": 691738,
+   "to_ram_bytes": 12992
+}
+)=====";
+   validate_ramburn_return(bob, 1, "burn RAM memo",
+                           "action_return_ramtransfer", expected_ramburn_return_data );
+
+} FC_LOG_AND_RETHROW()
+
+
+// buyramself
+BOOST_FIXTURE_TEST_CASE( buy_ram_self, eosio_system_tester ) try {
+   const std::vector<account_name> accounts = { "alice"_n };
+   create_accounts_with_resources( accounts );
+   const account_name alice = accounts[0];
+
+   transfer( config::system_account_name, alice, core_sym::from_string("100.0000"), config::system_account_name );
+   const uint64_t alice_before = get_total_stake( alice )["ram_bytes"].as_uint64();
+   BOOST_REQUIRE_EQUAL( success(), buyramself( alice, core_sym::from_string("1.0000")) );
+   const uint64_t alice_after = get_total_stake( alice )["ram_bytes"].as_uint64();
+   BOOST_REQUIRE_EQUAL( alice_before + 68375, alice_after );
+
+   const char* expected_buyramself_return_data = R"=====(
+{
+   "payer": "alice",
+   "receiver": "alice",
+   "quantity": "2.0000 TST",
+   "bytes_purchased": 136750,
+   "ram_bytes": 213117
+}
+)=====";
+
+   validate_buyramself_return(alice, core_sym::from_string("2.0000"),
+                       "action_return_buyram", expected_buyramself_return_data );
+} FC_LOG_AND_RETHROW()
+
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Change Description

#### Ram Transfer
New RAM system contract action to transfer RAM from one account to another without any fees.
- Charges 0% fee to transfer
- Only uncommited RAM can be transferred
- Notify `to` & `from` using `require_recipient`
- Memo cannot exceed 256 bytes
- returns struct `action_return_ramtransfer`

#### Ram Burn
New RAM system contract action to burn RAM from owner account.
- Burned RAM is transferred to `eosio.null` account
- Should have no impact on RAM Bancor market, RAM supply should remain unchanged
- returns struct `action_return_ramtransfer`

#### Ram Logging 
Add buy RAM logging by including additional inline actions and notifications via the use of `require_recipient`.

`bytes` & `quant` are computed values based on Bancor algorithm market.

This allows `payer` or `receiver` to confirm exact bytes sent/received via notifications.

#### Buy Ram
- returns struct `action_return_buyram`

#### Buy Ram Bytes 
- returns struct `action_return_buyram`

#### Buy Ram Self 
- returns struct `action_return_buyram`

#### Sell Ram
- returns struct `action_return_sellram`

## API Changes

- Add `require_recipient(receiver)` on `buyram` & `buyrambytes` actions

#### ACTION: `ramtransfer`

- `from {name}`
- `to {name}`
- `bytes {int64}`
- `memo {string}`

#### ACTION: `ramburn`

- `owner {name}`
- `bytes {int64}`
- `memo {string}`

#### ACTION: `logbuyram`

```c++
/**
 * Logging for buyram & buyrambytes action
 *
 * @param payer - the ram buyer,
 * @param receiver - the ram receiver,
 * @param quantity - the quantity of tokens to buy ram with.
 * @param bytes - the quantity of ram to buy specified in bytes.
 * @param ram_bytes - the ram bytes held by receiver after the action.
 */
[[eosio::action]]
void logbuyram( const name& payer, const name& receiver, const asset& quantity, int64_t bytes, int64_t ram_bytes );
```

#### ACTION: `buyram` `buyrambytes` `buyramself`
return struct `action_return_buyram`
```
"name": "action_return_buyram",
"base": "",
 "fields": [
                 {
                     "name": "payer",
                     "type": "name"
                 },
                 {
                     "name": "receiver",
                     "type": "name"
                 },
                 {
                     "name": "quantity",
                     "type": "asset"
                 },
                 {
                     "name": "bytes_purchased",
                     "type": "int64"
                 },
                 {
                     "name": "ram_bytes",
                     "type": "int64"
                 }
]
```

#### ACTION: `ramtransfer` `ramburn`
returns struct `action_return_ramtransfer`
```
"name": "action_return_ramtransfer",
"base": "",
"fields": [
            {
               "name": "from",
               "type": "name"
            },
            {
               "name": "to",
               "type": "name"
            },
            {
               "name": "bytes",
               "type": "int64"
            },
            {
               "name": "from_ram_bytes",
               "type": "int64"
            },
            {
               "name": "to_ram_bytes",
               "type": "int64"
            }
]
```

#### ACTION: `sellram`
returns struct `action_return_sellram`
```
"name": "action_return_sellram",
"base": "",
"fields": [
                 {
                     "name": "account",
                     "type": "name"
                 },
                 {
                     "name": "quantity",
                     "type": "asset"
                 },
                 {
                     "name": "bytes_sold",
                     "type": "int64"
                 },
                 {
                     "name": "ram_bytes",
                     "type": "int64"
                 }
]
```

## Preconditions

#### Ram Transfer Preconditions
- `from` must have sufficient `ram_bytes` prior to transfer
- `from` decrease `ram_bytes` by `bytes`
- `to` must exists
- `to` account can be a contract
- `to` account can have zero available RAM bytes
- `to` increase `ram_bytes` by `bytes`
- handle `ram_managed` accounts

#### Ram Burn Preconditions
- Same conditions as `ramtransfer` action

## Usecases

#### Ram Transfer Usecases
1. Improves EOS account creation:
  a. Create `newaccount` using `ramtransfer` instead of `buyram` or `buyrambytes`

2. Improves RAM token wrapper development:
  a. Receive RAM without buy/sell actions (no fees to transferring RAM)
  b. Existing RAM supply can be transferred to existing RAM token wrappers
  c. DeFi composability using `memo` field