### PR TITLE
[3.6] Update README to Spring

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,54 +37,54 @@ The `main` branch contains the latest state of development; do not use this for 
 
 [CDT](https://github.com/AntelopeIO/cdt) is required to build contracts. Any operating systems supported by CDT is sufficient to build the system contracts.
 
-To build and run the tests as well, [Leap](https://github.com/AntelopeIO/leap) is also required as a dependency, which may have its further restrictions on supported operating systems.
+To build and run the tests as well, [Spring](https://github.com/AntelopeIO/spring) is also required as a dependency, which may have its further restrictions on supported operating systems.
 
 ## Building
 
-The build guide below will assume you are running Ubuntu 20.04. However, as mentioned above, other operating systems may also be supported.
+The build guide below will assume you are running Ubuntu 22.04. However, as mentioned above, other operating systems may also be supported.
 
 ### Build or install CDT dependency
 
-The CDT dependency is required. This release of the system contracts requires at least version 3.0 of CDT. 
+The CDT dependency is required. This release of the system contracts requires at least version 4.1 of CDT. 
 
 The easiest way to satisfy this dependency is to install CDT on your system through a package. Find the release of a compatible version of CDT from its [releases page](https://github.com/AntelopeIO/cdt/releases), download the package file appropriate for your OS from the attached assets, and install the package.
 
 Alternatively, you can build CDT from source. Please refer to the guide in the [CDT README](https://github.com/AntelopeIO/cdt#building-from-source) for instructions on how to do this. If you choose to go with building CDT from source, please keep the path to the build directory in the shell environment variable `CDT_BUILD_PATH` for later use when building the system contracts.
 
-### Optionally build Leap dependency
+### Optionally build Spring dependency
 
-The Leap dependency is optional. It is only needed if you wish to also build the tests using the `BUILD_TESTS` CMake flag.
+The Spring dependency is optional. It is only needed if you wish to also build the tests using the `BUILD_TESTS` CMake flag.
 
-Unfortunately, it is not currently possible to satisfy the contract testing dependencies through the Leap packages made available from the [Leap releases page](https://github.com/AntelopeIO/leap/releases). So if you want to build the contract tests, you will first need to build Leap from source.
+Unfortunately, it is not currently possible to satisfy the contract testing dependencies through the Spring packages made available from the [Spring releases page](https://github.com/AntelopeIO/spring/releases). So if you want to build the contract tests, you will first need to build Spring from source.
 
-Please refer to the guide in the [Leap README](https://github.com/AntelopeIO/leap#building-from-source) for instructions on how to do this. If you choose to go with building Leap from source, please keep the path to the build directory in the shell environment variable `LEAP_BUILD_PATH` for later use when building the system contracts.
+Please refer to the guide in the [Spring README](https://github.com/AntelopeIO/spring#building-from-source) for instructions on how to do this. If you choose to go with building Spring from source, please keep the path to the build directory in the shell environment variable `SPRING_BUILD_PATH` for later use when building the system contracts.
 
 ### Build system contracts
 
-Beyond CDT and optionally Leap (if also building the tests), no additional dependencies are required to build the system contracts.
+Beyond CDT and optionally Spring (if also building the tests), no additional dependencies are required to build the system contracts.
 
-The instructions below assume you are building the system contracts with tests, have already built Leap from source, and have the CDT dependency installed on your system. For some other configurations, expand the hidden panels placed lower within this section.
+The instructions below assume you are building the system contracts with tests, have already built Spring from source, and have the CDT dependency installed on your system. For some other configurations, expand the hidden panels placed lower within this section.
 
 For all configurations, you should first `cd` into the directory containing cloned system contracts repository.
 
-Build system contracts with tests using Leap built from source and with installed CDT package:
+Build system contracts with tests using Spring built from source and with installed CDT package:
 
 ```shell
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -Dleap_DIR="${LEAP_BUILD_PATH}/lib/cmake/leap" ..
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -Dspring_DIR="${LEAP_BUILD_PATH}/lib/cmake/spring" ..
 make -j $(nproc)
 ```
 
 **Note:** `CMAKE_BUILD_TYPE` has no impact on the WASM files generated for the contracts. It only impacts how the test binaries are built. Use `-DCMAKE_BUILD_TYPE=Debug` if you want to create test binaries that you can debug.
 
 <details>
-<summary>Build system contracts with tests using Leap and CDT both built from source</summary>
+<summary>Build system contracts with tests using Spring and CDT both built from source</summary>
 
 ```shell
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -Dcdt_DIR="${CDT_BUILD_PATH}/lib/cmake/cdt" -Dleap_DIR="${LEAP_BUILD_PATH}/lib/cmake/leap" ..
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -Dcdt_DIR="${CDT_BUILD_PATH}/lib/cmake/cdt" -Dspring_DIR="${LEAP_BUILD_PATH}/lib/cmake/spring" ..
 make -j $(nproc)
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The build guide below will assume you are running Ubuntu 22.04. However, as ment
 
 ### Build or install CDT dependency
 
-The CDT dependency is required. This release of the system contracts requires at least version 4.1 of CDT. 
+The CDT dependency is required. This release of the system contracts requires at least version 4.1 of CDT.
 
 The easiest way to satisfy this dependency is to install CDT on your system through a package. Find the release of a compatible version of CDT from its [releases page](https://github.com/AntelopeIO/cdt/releases), download the package file appropriate for your OS from the attached assets, and install the package.
 
@@ -72,7 +72,7 @@ Build system contracts with tests using Spring built from source and with instal
 ```shell
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -Dspring_DIR="${LEAP_BUILD_PATH}/lib/cmake/spring" ..
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -Dspring_DIR="${SPRING_BUILD_PATH}/lib/cmake/spring" ..
 make -j $(nproc)
 ```
 
@@ -84,7 +84,7 @@ make -j $(nproc)
 ```shell
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -Dcdt_DIR="${CDT_BUILD_PATH}/lib/cmake/cdt" -Dspring_DIR="${LEAP_BUILD_PATH}/lib/cmake/spring" ..
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -Dcdt_DIR="${CDT_BUILD_PATH}/lib/cmake/cdt" -Dspring_DIR="${SPRING_BUILD_PATH}/lib/cmake/spring" ..
 make -j $(nproc)
 ```
 

--- a/docs/01_key-concepts/02_system_resources.md
+++ b/docs/01_key-concepts/02_system_resources.md
@@ -17,6 +17,6 @@ As a developer if you want to estimate how much CPU and NET a transaction requir
 
 * Use the `--dry-run` option for the `dune -- cleos push transaction` command.
 * Use any tool that can pack a transaction and send it to the blockchain and specify the `--dry-run` option.
-* Use the chain API endpoint [`compute_transaction`](https://github.com/AntelopeIO/leap/blob/51c11175e54831474a89a449beea1fb067e3d1e9/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp#L489).
+* Use the chain API endpoint [`compute_transaction`](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp#L557).
 
 In all cases, when the transaction is processed, the blockchain node simulates the execution of the transaction and, as a consequence, the state of the blockchain is changed speculatively, which allows for the CPU and NET measurements to be done. However, the transaction is not sent to the blockchain and the caller receives the estimated CPU and NET costs in return.

--- a/docs/01_key-concepts/03_cpu.md
+++ b/docs/01_key-concepts/03_cpu.md
@@ -14,10 +14,10 @@ dune -- cleos get consensus_parameters
 
 For accounts that execute transactions, the blockchain calculates and updates the remaining resources with each block before each transaction is executed. When a transaction is prepared for execution, the blockchain determines whether the payer account has enough CPU to cover the transaction execution. To calculate the necessary CPU, the node that actively builds the current block measures the time to execute the transaction. If the account has enough CPU, the transaction is executed; otherwise it is rejected. For technical details please refer to the following links:
 
-* [The CPU configuration variables](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/include/eosio/chain/config.hpp#L69)
+* [The CPU configuration variables](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/include/eosio/chain/config.hpp#L69-L73)
 * [The transaction initialization](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/controller.cpp#L3012)
-* [The transaction CPU billing](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/controller.cpp#L2630)
-* [The check of CPU usage for a transaction](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/controller.cpp#L2620)[Update here as well](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/controller.cpp#L2787)
+* [The transaction CPU billing](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/controller.cpp#L3030)
+* [The check of CPU usage for a transaction](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/transaction_context.cpp#L457)
 
 ## Subjective CPU Billing
 

--- a/docs/01_key-concepts/03_cpu.md
+++ b/docs/01_key-concepts/03_cpu.md
@@ -14,10 +14,10 @@ dune -- cleos get consensus_parameters
 
 For accounts that execute transactions, the blockchain calculates and updates the remaining resources with each block before each transaction is executed. When a transaction is prepared for execution, the blockchain determines whether the payer account has enough CPU to cover the transaction execution. To calculate the necessary CPU, the node that actively builds the current block measures the time to execute the transaction. If the account has enough CPU, the transaction is executed; otherwise it is rejected. For technical details please refer to the following links:
 
-* [The CPU configuration variables](https://github.com/AntelopeIO/leap/blob/a4c29608472dd195d36d732052784aadc3a779cb/libraries/chain/include/eosio/chain/config.hpp#L66)
-* [The transaction initialization](https://github.com/AntelopeIO/leap/blob/e55669c42dfe4ac112e3072186f3a449936c0c61/libraries/chain/controller.cpp#L1559)
-* [The transaction CPU billing](https://github.com/AntelopeIO/leap/blob/e55669c42dfe4ac112e3072186f3a449936c0c61/libraries/chain/controller.cpp#L1577)
-* [The check of CPU usage for a transaction](https://github.com/AntelopeIO/leap/blob/a4c29608472dd195d36d732052784aadc3a779cb/libraries/chain/transaction_context.cpp#L381)
+* [The CPU configuration variables](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/include/eosio/chain/config.hpp#L69)
+* [The transaction initialization](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/controller.cpp#L3012)
+* [The transaction CPU billing](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/controller.cpp#L2630)
+* [The check of CPU usage for a transaction](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/controller.cpp#L2620)[Update here as well](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/controller.cpp#L2787)
 
 ## Subjective CPU Billing
 

--- a/docs/01_key-concepts/04_net.md
+++ b/docs/01_key-concepts/04_net.md
@@ -14,10 +14,10 @@ dune -- cleos get consensus_parameters
 
 For the accounts that execute transactions, the blockchain calculates and updates the remaining resources for each block before each transaction is executed. When a transaction is prepared for execution, the blockchain determines whether the payer account has enough NET to cover the transaction execution. The necessary NET is calculated based on the transaction size, which is the size of the packed transaction as it is stored in the blockchain. If the account has enough NET resources, the transaction can be executed; otherwise it is rejected. For technical details please refer to the following sources:
 
-* [The NET configuration variables](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/include/eosio/chain/config.hpp#L60)
+* [The NET configuration variables](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/include/eosio/chain/config.hpp#L60-L67)
 * [The transaction initialization](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/controller.cpp#L3012)
 * [The transaction NET billing](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/controller.cpp#L3030)
-* [The check of NET usage for a transaction](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/transaction_context.cpp#L394)
+* [The check of NET usage for a transaction](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/transaction_context.cpp#L416)
 
 ## How To Rent NET
 

--- a/docs/01_key-concepts/04_net.md
+++ b/docs/01_key-concepts/04_net.md
@@ -14,10 +14,10 @@ dune -- cleos get consensus_parameters
 
 For the accounts that execute transactions, the blockchain calculates and updates the remaining resources for each block before each transaction is executed. When a transaction is prepared for execution, the blockchain determines whether the payer account has enough NET to cover the transaction execution. The necessary NET is calculated based on the transaction size, which is the size of the packed transaction as it is stored in the blockchain. If the account has enough NET resources, the transaction can be executed; otherwise it is rejected. For technical details please refer to the following sources:
 
-* [The NET configuration variables](https://github.com/AntelopeIO/leap/blob/a4c29608472dd195d36d732052784aadc3a779cb/libraries/chain/include/eosio/chain/config.hpp#L57)
-* [The transaction initialization](https://github.com/AntelopeIO/leap/blob/e55669c42dfe4ac112e3072186f3a449936c0c61/libraries/chain/controller.cpp#L1559)
-* [The transaction NET billing](https://github.com/AntelopeIO/leap/blob/e55669c42dfe4ac112e3072186f3a449936c0c61/libraries/chain/controller.cpp#L1577)
-* [The check of NET usage for a transaction](https://github.com/AntelopeIO/leap/blob/a4c29608472dd195d36d732052784aadc3a779cb/libraries/chain/transaction_context.cpp#L376)
+* [The NET configuration variables](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/include/eosio/chain/config.hpp#L60)
+* [The transaction initialization](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/controller.cpp#L3012)
+* [The transaction NET billing](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/controller.cpp#L3030)
+* [The check of NET usage for a transaction](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/transaction_context.cpp#L394)
 
 ## How To Rent NET
 

--- a/docs/01_key-concepts/05_ram.md
+++ b/docs/01_key-concepts/05_ram.md
@@ -80,7 +80,7 @@ The necessary RAM needed for a smart contract to store its data is calculated fr
 As a developer, to understand the amount of RAM your smart contract needs, pay attention to the data structure underlying the multi-index tables your smart contract instantiates and uses. The data structure underlying one multi-index table defines a row in the table. Each data member of the data structure corresponds with a row cell of the table.
 To approximate the amount of RAM one multi-index row needs to store on the blockchain, you have to add the size of the type of each data member and the memory overheads for each of the defined indexes, if any. Find below the overheads defined by the EOS code for multi-index tables, indexes, and data types:
 
-* [Multi-index RAM bytes overhead](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/include/eosio/chain/config.hpp#L6)
+* [Multi-index RAM bytes overhead](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/include/eosio/chain/contract_table_objects.hpp#L242-L285)
 * [Overhead per row per index RAM bytes](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/include/eosio/chain/config.hpp#L114)
 * [Fixed overhead shared vector RAM bytes](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/include/eosio/chain/config.hpp#L113)
 * [Overhead per account RAM bytes](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/include/eosio/chain/config.hpp#L115)

--- a/docs/01_key-concepts/05_ram.md
+++ b/docs/01_key-concepts/05_ram.md
@@ -80,9 +80,9 @@ The necessary RAM needed for a smart contract to store its data is calculated fr
 As a developer, to understand the amount of RAM your smart contract needs, pay attention to the data structure underlying the multi-index tables your smart contract instantiates and uses. The data structure underlying one multi-index table defines a row in the table. Each data member of the data structure corresponds with a row cell of the table.
 To approximate the amount of RAM one multi-index row needs to store on the blockchain, you have to add the size of the type of each data member and the memory overheads for each of the defined indexes, if any. Find below the overheads defined by the EOS code for multi-index tables, indexes, and data types:
 
-* [Multi-index RAM bytes overhead](https://github.com/AntelopeIO/leap/blob/f6643e434e8dc304bba742422dd036a6fbc1f039/libraries/chain/include/eosio/chain/contract_table_objects.hpp#L240)
-* [Overhead per row per index RAM bytes](https://github.com/AntelopeIO/leap/blob/a4c29608472dd195d36d732052784aadc3a779cb/libraries/chain/include/eosio/chain/config.hpp#L109)
-* [Fixed overhead shared vector RAM bytes](https://github.com/AntelopeIO/leap/blob/a4c29608472dd195d36d732052784aadc3a779cb/libraries/chain/include/eosio/chain/config.hpp#L108)
-* [Overhead per account RAM bytes](https://github.com/AntelopeIO/leap/blob/a4c29608472dd195d36d732052784aadc3a779cb/libraries/chain/include/eosio/chain/config.hpp#L110)
-* [Setcode RAM bytes multiplier](https://github.com/AntelopeIO/leap/blob/a4c29608472dd195d36d732052784aadc3a779cb/libraries/chain/include/eosio/chain/config.hpp#L111)
-* [RAM usage update function](https://github.com/AntelopeIO/leap/blob/9f0679bd0a42d6c24a966bb79de6d8c0591872a5/libraries/chain/apply_context.cpp#L725)
+* [Multi-index RAM bytes overhead](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/include/eosio/chain/config.hpp#L6)
+* [Overhead per row per index RAM bytes](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/include/eosio/chain/config.hpp#L114)
+* [Fixed overhead shared vector RAM bytes](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/include/eosio/chain/config.hpp#L113)
+* [Overhead per account RAM bytes](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/include/eosio/chain/config.hpp#L115)
+* [Setcode RAM bytes multiplier](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/include/eosio/chain/config.hpp#L116)
+* [RAM usage update function](https://github.com/AntelopeIO/spring/blob/7254bab917a17bcc0d82d23d03f4173176150239/libraries/chain/apply_context.cpp#L734)

--- a/docs/04_guides/05_how-to-create-issue-and-transfer-a-token.md
+++ b/docs/04_guides/05_how-to-create-issue-and-transfer-a-token.md
@@ -116,7 +116,7 @@ executed transaction: 60d334850151cb95c35fe31ce2e8b536b51441c5fd4c3f2fea98edcc6d
 warning: transaction executed locally, but may not be confirmed by the network yet         ]
 ```
 
-Now check if "bob" got the tokens using [cleos get currency balance](https://docs.eosnetwork.com/leap/latest/cleos/command-reference/get/currency-balance)
+Now check if "bob" got the tokens using [cleos get currency balance](https://github.com/AntelopeIO/spring/blob/main/docs/02_cleos/03_command-reference/get/currency-balance.md)
 
 ```shell
 cleos get currency balance eosio.token bob NEWT

--- a/docs/04_guides/05_how-to-create-issue-and-transfer-a-token.md
+++ b/docs/04_guides/05_how-to-create-issue-and-transfer-a-token.md
@@ -116,7 +116,7 @@ executed transaction: 60d334850151cb95c35fe31ce2e8b536b51441c5fd4c3f2fea98edcc6d
 warning: transaction executed locally, but may not be confirmed by the network yet         ]
 ```
 
-Now check if "bob" got the tokens using [cleos get currency balance](https://github.com/AntelopeIO/spring/blob/main/docs/02_cleos/03_command-reference/get/currency-balance.md)
+Now check if "bob" got the tokens using [cleos get currency balance](https://github.com/AntelopeIO/spring/blob/v1.0.0-rc2/docs/02_cleos/03_command-reference/get/currency-balance.md)
 
 ```shell
 cleos get currency balance eosio.token bob NEWT


### PR DESCRIPTION
Update README build instructions to reference spring, and update required CDT version to 4.1