### PR TITLE
Account Name Restriction in System Contract

### DIFF
--- a/contracts/eosio.system/include/eosio.system/canon_name.hpp
+++ b/contracts/eosio.system/include/eosio.system/canon_name.hpp
@@ -1,0 +1,75 @@
+#include <eosio.system/eosio.system.hpp>
+#include <cassert>
+
+namespace eosiosystem {
+
+// -------------------------------------------------------------------------------------------
+struct canon_name_t
+{
+   uint64_t _value; // all significant characters are shifted to the least significant position
+   uint64_t _size;  // number of significant characters
+   bool     _valid_pattern;
+
+   uint64_t mask() const { return (1ull << (_size * 5)) - 1; }
+   uint64_t size() const { return _size; }
+   bool     valid() const { return _valid_pattern; }
+
+   // starts from the end, so n[0] is the last significant character of the name
+   uint64_t operator[](uint64_t i) const { return (_value >> (5 * i)) & 0x1F; }
+
+   canon_name_t(name n)
+   {
+      uint64_t v         = n.value;
+      auto     num_zeros = std::countr_zero(v);
+      _valid_pattern = (num_zeros >= 4) && (num_zeros < 64); // 13th char must be zero, and pattern should not be empty
+
+      if (_valid_pattern) {
+         uint64_t shift = 4 + ((num_zeros - 4) / 5) * 5;
+         _value         = v >> shift;
+         auto sig_bits  = 64 - shift;
+         _size          = sig_bits / 5;
+      }
+   }
+
+   // returns true if account_name ends with the same characters as `this`, preceded by a `.` (zero) character
+   bool is_suffix_of(canon_name_t account_name) const
+   {
+      assert(_valid_pattern && _size < account_name._size);
+      if (((_value ^ account_name._value) & mask()) != 0)
+         return false;
+
+      // pattern matches the end of account_name. To be a suffix it has to be preceded by a dot in account_name
+      return account_name[size()] == 0;
+   }
+
+   bool found_in(canon_name_t account_name) const
+   {
+      assert(_valid_pattern && _size < account_name._size);
+      auto   sz   = size();
+      size_t diff = account_name.size() - sz + 1;
+      for (size_t i = 0; i < diff; ++i)
+         if (((_value ^ (account_name._value >> (5 * i))) & mask()) == 0)
+            return true;
+      return false;
+   }
+};
+
+// -------------------------------------------------------------------------------------------
+bool name_allowed(name account, name patt)
+{
+   canon_name_t pattern(patt);
+   canon_name_t account_name(account);
+
+   if (!pattern.valid())
+      return true; // ignore invalid patterns
+
+   if (pattern.size() >= account_name.size())
+      return true;
+   if (pattern.is_suffix_of(account_name))
+      return true;
+   if (pattern.found_in(account_name))
+      return false;
+   return true;
+}
+
+} // namespace eosiosystem

--- a/contracts/eosio.system/include/eosio.system/canon_name.hpp
+++ b/contracts/eosio.system/include/eosio.system/canon_name.hpp
@@ -8,22 +8,20 @@ struct canon_name_t
 {
    uint64_t _value; // all significant characters are shifted to the least significant position
    uint64_t _size;  // number of significant characters
-   bool     _valid_pattern;
 
-   uint64_t mask() const { return (1ull << (_size * 5)) - 1; }
-   uint64_t size() const { return _size; }
-   bool     valid() const { return _valid_pattern; }
+   uint64_t mask()  const { return (1ull << (_size * 5)) - 1; }
+   uint64_t size()  const { return _size; }
+   bool     valid() const { return _size != 0; }
 
    // starts from the end, so n[0] is the last significant character of the name
    uint64_t operator[](uint64_t i) const { return (_value >> (5 * i)) & 0x1F; }
 
-   canon_name_t(name n)
-   {
+   canon_name_t(name n) {
       uint64_t v         = n.value;
       auto     num_zeros = std::countr_zero(v);
-      _valid_pattern = (num_zeros >= 4) && (num_zeros < 64); // 13th char must be zero, and pattern should not be empty
-
-      if (_valid_pattern) {
+      if ((num_zeros < 4) || (num_zeros == 64)) { // 13th char must be zero, and pattern should not be empty
+         _size = 0;                               // zero size denotes an invalid pattern
+      } else {
          uint64_t shift = 4 + ((num_zeros - 4) / 5) * 5;
          _value         = v >> shift;
          auto sig_bits  = 64 - shift;
@@ -32,19 +30,24 @@ struct canon_name_t
    }
 
    // returns true if account_name ends with the same characters as `this`, preceded by a `.` (zero) character
-   bool is_suffix_of(canon_name_t account_name) const
-   {
-      assert(_valid_pattern && _size < account_name._size);
+   bool is_suffix_of(canon_name_t account_name) const {
+      assert(valid());
+      if (size() > account_name.size())
+         return false;
+
       if (((_value ^ account_name._value) & mask()) != 0)
          return false;
 
-      // pattern matches the end of account_name. To be a suffix it has to be preceded by a dot in account_name
-      return account_name[size()] == 0;
+      // pattern matches the end of account_name. To be a suffix it has to either be the same length (i.e. exact match),
+      // or be preceded by a dot in account_name
+      return (size() == account_name.size()) || (account_name[size()] == 0);
    }
 
-   bool found_in(canon_name_t account_name) const
-   {
-      assert(_valid_pattern && _size < account_name._size);
+   bool found_in(canon_name_t account_name) const {
+      assert(valid());
+      if (size() > account_name.size())
+         return false;
+
       auto   sz   = size();
       size_t diff = account_name.size() - sz + 1;
       for (size_t i = 0; i < diff; ++i)
@@ -55,7 +58,7 @@ struct canon_name_t
 };
 
 // -------------------------------------------------------------------------------------------
-bool name_allowed(name account, name patt)
+static inline bool name_allowed(name account, name patt)
 {
    canon_name_t pattern(patt);
    canon_name_t account_name(account);
@@ -63,8 +66,6 @@ bool name_allowed(name account, name patt)
    if (!pattern.valid())
       return true; // ignore invalid patterns
 
-   if (pattern.size() >= account_name.size())
-      return true;
    if (pattern.is_suffix_of(account_name))
       return true;
    if (pattern.found_in(account_name))

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -16,7 +16,6 @@
 #include <optional>
 #include <string>
 #include <type_traits>
-#include <unordered_set>
 
 #ifdef CHANNEL_RAM_AND_NAMEBID_FEES_TO_REX
 #undef CHANNEL_RAM_AND_NAMEBID_FEES_TO_REX

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -103,7 +103,7 @@ namespace eosiosystem {
     * the contract level (`newaccount`, `updateauth`, `deleteauth`, `linkauth`, `unlinkauth`, `canceldelay`, `onerror`,
     * `setabi`, `setcode`), they are just declared in the contract so they will show in the contract's ABI and users
     * will be able to push those actions to the chain via the account holding the `eosio.system` contract, but the
-    * implementation is at the EOSIO core level. They are referred to as EOSIO native actions.
+    * implementation is at the core level. They are referred to as host native actions.
     *
     * - Users can stake tokens for CPU and Network bandwidth, and then vote for producers or
     *    delegate their vote to a proxy.

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -983,7 +983,7 @@ namespace eosiosystem {
           * @param blacklisted_name_patterns - vector of name patterns to add to the blacklist
           */
          [[eosio::action]]
-         void addblnames( const std::vector<name>& blacklisted_name_patterns );
+         void addblnames( std::vector<name> blacklisted_name_patterns );
 
          /**
           * Remove names from the `account_name_blacklist` singleton.
@@ -997,7 +997,7 @@ namespace eosiosystem {
           * @param allowed_name_patterns - vector of name patterns to remove from the blacklist
           */
          [[eosio::action]]
-         void rmblnames( const std::vector<name>& allowed_name_patterns );
+         void rmblnames( std::vector<name> allowed_name_patterns );
 
 
          /**

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -982,7 +982,7 @@ namespace eosiosystem {
           * @param blacklisted_name_patterns - vector of name patterns to add to the blacklist
           */
          [[eosio::action]]
-         void addblnames( std::vector<name> blacklisted_name_patterns );
+         void addblnames( std::vector<name> patterns );
 
          /**
           * Remove names from the `account_name_blacklist` singleton.
@@ -996,7 +996,7 @@ namespace eosiosystem {
           * @param allowed_name_patterns - vector of name patterns to remove from the blacklist
           */
          [[eosio::action]]
-         void rmblnames( std::vector<name> allowed_name_patterns );
+         void rmblnames( std::vector<name> patterns );
 
 
          /**

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -379,7 +379,7 @@ namespace eosiosystem {
    // A single entry storing a vector of names, each of which is a pattern that new account names
    // are checked against (when the `newaccount` is called), in order to reject the creation
    // of accounts whose name matches patterns in the blacklist.
-   struct [[eosio::table("actblacklist"), eosio::contract("eosio.system")]] account_name_blacklist {
+   struct [[eosio::table("acctdenylist"), eosio::contract("eosio.system")]] account_name_blacklist {
       std::vector<name> disallowed;
 
       uint64_t primary_key() const { return 0; }
@@ -387,7 +387,7 @@ namespace eosiosystem {
       EOSLIB_SERIALIZE( account_name_blacklist, (disallowed) )
    };
 
-   typedef eosio::multi_index< "actblacklist"_n, account_name_blacklist >  account_name_blacklist_table;
+   typedef eosio::multi_index< "acctdenylist"_n, account_name_blacklist >  account_name_blacklist_table;
 
    // Voter info. Voter info stores information about the voter:
    // - `owner` the voter

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -95,8 +95,7 @@ namespace eosiosystem {
 #endif
 
    /**
-    * The `eosio.system` smart contract is provided by `block.one` as a sample system contract, and it defines the
-    * structures and actions needed for blockchain's core functionality.
+    * The `eosio.system` smart contract defines the structures and actions needed for blockchain's core functionality.
     *
     * Just like in the `eosio.bios` sample contract implementation, there are a few actions which are not implemented at
     * the contract level (`newaccount`, `updateauth`, `deleteauth`, `linkauth`, `unlinkauth`, `canceldelay`, `onerror`,
@@ -815,8 +814,7 @@ namespace eosiosystem {
                                > powerup_order_table;
 
    /**
-    * The `eosio.system` smart contract is provided by `block.one` as a sample system contract, and it defines the
-    * structures and actions needed for blockchain's core functionality.
+    * The `eosio.system` smart contract defines the structures and actions needed for blockchain's core functionality.
     *
     * Just like in the `eosio.bios` sample contract implementation, there are a few actions which are not implemented at
     * the contract level (`newaccount`, `updateauth`, `deleteauth`, `linkauth`, `unlinkauth`, `canceldelay`, `onerror`,

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -381,7 +381,7 @@ namespace eosiosystem {
    // A single entry storing a vector of names, each of which is a pattern that new account names
    // are checked against (when the `newaccount` is called), in order to reject the creation
    // of accounts whose name matches patterns in the blacklist.
-   struct [[eosio::table("accountnmbl"), eosio::contract("eosio.system")]] account_name_blacklist {
+   struct [[eosio::table("actblacklist"), eosio::contract("eosio.system")]] account_name_blacklist {
       std::vector<name> disallowed;
 
       uint64_t primary_key() const { return 0; }
@@ -389,7 +389,7 @@ namespace eosiosystem {
       EOSLIB_SERIALIZE( account_name_blacklist, (disallowed) )
    };
 
-   typedef eosio::multi_index< "accountnmbl"_n, account_name_blacklist >  account_name_blacklist_table;
+   typedef eosio::multi_index< "actblacklist"_n, account_name_blacklist >  account_name_blacklist_table;
 
    // Voter info. Voter info stores information about the voter:
    // - `owner` the voter
@@ -823,7 +823,7 @@ namespace eosiosystem {
     * the contract level (`newaccount`, `updateauth`, `deleteauth`, `linkauth`, `unlinkauth`, `canceldelay`, `onerror`,
     * `setabi`, `setcode`), they are just declared in the contract so they will show in the contract's ABI and users
     * will be able to push those actions to the chain via the account holding the `eosio.system` contract, but the
-    * implementation is at the EOSIO core level. They are referred to as EOSIO native actions.
+    * implementation is at the core level. They are referred to as host native actions.
     *
     * - Users can stake tokens for CPU and Network bandwidth, and then vote for producers or
     *    delegate their vote to a proxy.

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -378,6 +378,19 @@ namespace eosiosystem {
 
    typedef eosio::multi_index< "finkeyidgen"_n, fin_key_id_generator_info >  fin_key_id_gen_table;
 
+   // A single entry storing a vector of names, each of which is a pattern that new account names
+   // are checked against (when the `newaccount` is called), in order to reject the creation
+   // of accounts whose name matches patterns in the blacklist.
+   struct [[eosio::table("accountnmbl"), eosio::contract("eosio.system")]] account_name_blacklist {
+      std::vector<name> disallowed;
+
+      uint64_t primary_key() const { return 0; }
+
+      EOSLIB_SERIALIZE( account_name_blacklist, (disallowed) )
+   };
+
+   typedef eosio::multi_index< "accountnmbl"_n, account_name_blacklist >  account_name_blacklist_table;
+
    // Voter info. Voter info stores information about the voter:
    // - `owner` the voter
    // - `proxy` the proxy set by the voter, if any
@@ -957,6 +970,34 @@ namespace eosiosystem {
           */
          [[eosio::action]]
          void setacctcpu( const name& account, const std::optional<int64_t>& cpu_weight );
+
+         /**
+          * Add names to the `account_name_blacklist` singleton.
+          *
+          * The `account_name_blacklist` singleton contains a vector of names, each of which is a pattern that
+          * new account names are checked against (when the `newaccount` is called), in order to reject the creation
+          * of accounts whose name matches patterns in the blacklist.
+          *
+          * requires "eosio"_n permission
+          *
+          * @param blacklisted_name_patterns - vector of name patterns to add to the blacklist
+          */
+         [[eosio::action]]
+         void addblnames( const std::vector<name>& blacklisted_name_patterns );
+
+         /**
+          * Remove names from the `account_name_blacklist` singleton.
+          *
+          * The `account_name_blacklist` singleton contains a vector of names, each of which is a pattern that
+          * new account names are checked against (when the `newaccount` is called), in order to reject the creation
+          * of accounts whose name matches patterns in the blacklist.
+          *
+          * requires "eosio"_n permission
+          *
+          * @param allowed_name_patterns - vector of name patterns to remove from the blacklist
+          */
+         [[eosio::action]]
+         void rmblnames( const std::vector<name>& allowed_name_patterns );
 
 
          /**

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -981,7 +981,7 @@ namespace eosiosystem {
           * @param patterns - vector of name patterns to add to the blacklist
           */
          [[eosio::action]]
-         void denynames( std::vector<name> patterns );
+         void denynames( const std::vector<name>& patterns );
 
          /**
           * Remove names from the `account_name_blacklist` singleton.
@@ -996,7 +996,7 @@ namespace eosiosystem {
           * @param patterns - vector of name patterns to remove from the blacklist
           */
          [[eosio::action]]
-         void undenynames( std::vector<name> patterns );
+         void undenynames( const std::vector<name>& patterns );
 
          /**
           * The activate action, activates a protocol feature

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -981,7 +981,7 @@ namespace eosiosystem {
           * @param patterns - vector of name patterns to add to the blacklist
           */
          [[eosio::action]]
-         void addblnames( std::vector<name> patterns );
+         void denynames( std::vector<name> patterns );
 
          /**
           * Remove names from the `account_name_blacklist` singleton.
@@ -996,8 +996,7 @@ namespace eosiosystem {
           * @param patterns - vector of name patterns to remove from the blacklist
           */
          [[eosio::action]]
-         void rmblnames( std::vector<name> patterns );
-
+         void undenynames( std::vector<name> patterns );
 
          /**
           * The activate action, activates a protocol feature

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -975,11 +975,12 @@ namespace eosiosystem {
           *
           * The `account_name_blacklist` singleton contains a vector of names, each of which is a pattern that
           * new account names are checked against (when the `newaccount` is called), in order to reject the creation
-          * of accounts whose name matches patterns in the blacklist.
+          * of accounts whose name includes patterns in the blacklist.
+          * The "eosio"_n account is not subject to the blacklist restrictions.
           *
           * requires "eosio"_n permission
           *
-          * @param blacklisted_name_patterns - vector of name patterns to add to the blacklist
+          * @param patterns - vector of name patterns to add to the blacklist
           */
          [[eosio::action]]
          void addblnames( std::vector<name> patterns );
@@ -989,11 +990,12 @@ namespace eosiosystem {
           *
           * The `account_name_blacklist` singleton contains a vector of names, each of which is a pattern that
           * new account names are checked against (when the `newaccount` is called), in order to reject the creation
-          * of accounts whose name matches patterns in the blacklist.
+          * of accounts whose name includes patterns in the blacklist.
+          * The "eosio"_n account is not subject to the blacklist restrictions.
           *
           * requires "eosio"_n permission
           *
-          * @param allowed_name_patterns - vector of name patterns to remove from the blacklist
+          * @param patterns - vector of name patterns to remove from the blacklist
           */
          [[eosio::action]]
          void rmblnames( std::vector<name> patterns );

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -95,19 +95,24 @@ namespace eosiosystem {
    using blockchain_parameters_t = eosio::blockchain_parameters;
 #endif
 
-  /**
-   * The `eosio.system` smart contract is provided by `block.one` as a sample system contract, and it defines the structures and actions needed for blockchain's core functionality.
-   *
-   * Just like in the `eosio.bios` sample contract implementation, there are a few actions which are not implemented at the contract level (`newaccount`, `updateauth`, `deleteauth`, `linkauth`, `unlinkauth`, `canceldelay`, `onerror`, `setabi`, `setcode`), they are just declared in the contract so they will show in the contract's ABI and users will be able to push those actions to the chain via the account holding the `eosio.system` contract, but the implementation is at the EOSIO core level. They are referred to as EOSIO native actions.
-   *
-   * - Users can stake tokens for CPU and Network bandwidth, and then vote for producers or
-   *    delegate their vote to a proxy.
-   * - Producers register in order to be voted for, and can claim per-block and per-vote rewards.
-   * - Users can buy and sell RAM at a market-determined price.
-   * - Users can bid on premium names.
-   * - A resource exchange system (REX) allows token holders to lend their tokens,
-   *    and users to rent CPU and Network resources in return for a market-determined fee.
-   */
+   /**
+    * The `eosio.system` smart contract is provided by `block.one` as a sample system contract, and it defines the
+    * structures and actions needed for blockchain's core functionality.
+    *
+    * Just like in the `eosio.bios` sample contract implementation, there are a few actions which are not implemented at
+    * the contract level (`newaccount`, `updateauth`, `deleteauth`, `linkauth`, `unlinkauth`, `canceldelay`, `onerror`,
+    * `setabi`, `setcode`), they are just declared in the contract so they will show in the contract's ABI and users
+    * will be able to push those actions to the chain via the account holding the `eosio.system` contract, but the
+    * implementation is at the EOSIO core level. They are referred to as EOSIO native actions.
+    *
+    * - Users can stake tokens for CPU and Network bandwidth, and then vote for producers or
+    *    delegate their vote to a proxy.
+    * - Producers register in order to be voted for, and can claim per-block and per-vote rewards.
+    * - Users can buy and sell RAM at a market-determined price.
+    * - Users can bid on premium names.
+    * - A resource exchange system (REX) allows token holders to lend their tokens,
+    *    and users to rent CPU and Network resources in return for a market-determined fee.
+    */
 
    // A name bid, which consists of:
    // - a `newname` name that the bid is for
@@ -798,9 +803,14 @@ namespace eosiosystem {
                                > powerup_order_table;
 
    /**
-    * The `eosio.system` smart contract is provided by `block.one` as a sample system contract, and it defines the structures and actions needed for blockchain's core functionality.
+    * The `eosio.system` smart contract is provided by `block.one` as a sample system contract, and it defines the
+    * structures and actions needed for blockchain's core functionality.
     *
-    * Just like in the `eosio.bios` sample contract implementation, there are a few actions which are not implemented at the contract level (`newaccount`, `updateauth`, `deleteauth`, `linkauth`, `unlinkauth`, `canceldelay`, `onerror`, `setabi`, `setcode`), they are just declared in the contract so they will show in the contract's ABI and users will be able to push those actions to the chain via the account holding the `eosio.system` contract, but the implementation is at the EOSIO core level. They are referred to as EOSIO native actions.
+    * Just like in the `eosio.bios` sample contract implementation, there are a few actions which are not implemented at
+    * the contract level (`newaccount`, `updateauth`, `deleteauth`, `linkauth`, `unlinkauth`, `canceldelay`, `onerror`,
+    * `setabi`, `setcode`), they are just declared in the contract so they will show in the contract's ABI and users
+    * will be able to push those actions to the chain via the account holding the `eosio.system` contract, but the
+    * implementation is at the EOSIO core level. They are referred to as EOSIO native actions.
     *
     * - Users can stake tokens for CPU and Network bandwidth, and then vote for producers or
     *    delegate their vote to a proxy.

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -412,6 +412,10 @@ namespace eosiosystem {
       auto add_patterns_to = [&patterns](auto& current) {
          // number of blackcklist name patterns expected to be small, so quadratic check OK
          for (auto n : patterns) {
+            // pattern should not be empty or more than 12 character long
+            if (n.value == 0 || (n.value & 0xF) != 0)
+               continue; // silently ignore incorrect patterns
+
             if (std::find(std::cbegin(current), std::cend(current), n) == std::cend(current))
                current.push_back(n);
          }

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -398,10 +398,11 @@ namespace eosiosystem {
    }
 
    void system_contract::denynames( const std::vector<name>& patterns ) {
+      require_auth( get_self() );
+
       if (patterns.empty())
          return; // no-op for empty list, consistent with ignoring duplicate names.
 
-      require_auth( get_self() );
       check(patterns.size() <= 512, "Cannot provide more than 512 patterns in one action call");
 
       account_name_blacklist_table bl_table(get_self(), get_self().value);
@@ -428,10 +429,11 @@ namespace eosiosystem {
    }
 
    void system_contract::undenynames( const std::vector<name>& patterns ) {
+      require_auth( get_self() );
+
       if (patterns.empty())
          return; // no-op for empty list, consistent with ignoring duplicate names.
       
-      require_auth( get_self() );
       check(patterns.size() <= 512, "Cannot provide more than 512 patterns in one action call");
 
       account_name_blacklist_table bl_table(get_self(), get_self().value);

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -439,7 +439,8 @@ namespace eosiosystem {
       account_name_blacklist_table bl_table(get_self(), get_self().value);
       auto itr = bl_table.begin();
       bool present = (itr != bl_table.end());
-      check(present, "Current list of blacklisted name patterns is empty... cannot remove");
+      if (!present)
+         return; // no-op for empty blacklist table, consistent with ignoring names not in the list
 
       bl_table.modify(itr, same_payer, [&](auto& blacklist) {
          auto& current = blacklist.disallowed;

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -670,12 +670,12 @@ namespace eosiosystem {
             if( suffix == new_account_name ) {
                name_bid_table bids(get_self(), get_self().value);
                auto current = bids.find( new_account_name.value );
-               check( current != bids.end(), "no active bid for name: " + new_account_name.to_string());
+               check( current != bids.end(), "no active bid for name" );
                check( current->high_bidder == creator, "only highest bidder can claim" );
                check( current->high_bid < 0, "auction for name is not closed yet" );
                bids.erase( current );
             } else {
-               check( creator == suffix, "only " + suffix.to_string() + " may create " + new_account_name.to_string());
+               check( creator == suffix, "only suffix may create this account" );
             }
          }
     

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -437,7 +437,7 @@ namespace eosiosystem {
          }
       };
 
-      std::vector<name>&    _blacklist;
+      std::vector<name>& _blacklist;
    };
 
    void system_contract::addblnames( const std::vector<name>& blacklisted_name_patterns ) {
@@ -695,7 +695,7 @@ namespace eosiosystem {
             const std::vector<name>& blacklist{itr->disallowed};
             for (auto pattern : blacklist) {
                check(name_allowed(new_account_name, pattern),
-                     "Account name " + new_account_name.to_string() + " disallowed by rule: " + pattern.to_string());
+                     "Account name " + new_account_name.to_string() + " creation disallowed by rule: " + pattern.to_string());
             }
          }
       }

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -402,10 +402,7 @@ namespace eosiosystem {
       explicit blacklist_manager(std::vector<name>& blacklist) : _blacklist(blacklist) {}
 
       void add(const std::vector<name>& patterns) const {
-         std::unordered_set<name, _hash> already;
-
-         for (auto n : _blacklist)
-            already.insert(n);
+         std::unordered_set<name, _hash> already(std::cbegin(_blacklist), std::cend(_blacklist));
 
          for (auto n : patterns) {
             if (!already.contains(n))
@@ -414,10 +411,7 @@ namespace eosiosystem {
       }
 
       void remove(const std::vector<name>& patterns) const {
-         std::unordered_set<name, _hash> already;
-
-         for (auto n : _blacklist)
-            already.insert(n);
+         std::unordered_set<name, _hash> already(std::cbegin(_blacklist), std::cend(_blacklist));
 
          for (auto n : patterns) {
             if (already.contains(n))
@@ -676,16 +670,16 @@ namespace eosiosystem {
             if( suffix == new_account_name ) {
                name_bid_table bids(get_self(), get_self().value);
                auto current = bids.find( new_account_name.value );
-               check( current != bids.end(), "no active bid for name" );
+               check( current != bids.end(), "no active bid for name: " + new_account_name.to_string());
                check( current->high_bidder == creator, "only highest bidder can claim" );
                check( current->high_bid < 0, "auction for name is not closed yet" );
                bids.erase( current );
             } else {
-               check( creator == suffix, "only suffix may create this account" );
+               check( creator == suffix, "only " + suffix.to_string() + " may create " + new_account_name.to_string());
             }
          }
-
-         // also check that the account does not match a blacklist pattern stored in `account_name_blacklist_table`
+    
+         // check that the account does not match a blacklist pattern stored in `account_name_blacklist_table`
          // -------------------------------------------------------------------------------------------------------
          account_name_blacklist_table bl_table(get_self(), get_self().value);
          auto itr = bl_table.begin();

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -415,8 +415,8 @@ namespace eosiosystem {
          for (auto n : patterns) {
             // check that pattern is valid (pattern should not be empty or more than 12 character long)
             canon_name_t pattern(n);
-            if (!pattern.valid())
-               continue; // silently ignore incorrect patterns
+            check(pattern.valid(),
+                  n.value ? ("Pattern " + n.to_string() + " is not valid") : "Empty patterns are not allowed");
 
             if (std::find(std::cbegin(current), std::cend(current), n) == std::cend(current))
                current.push_back(n);

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -397,7 +397,7 @@ namespace eosiosystem {
       set_resource_limits( account, current_ram, current_net, cpu );
    }
 
-   void system_contract::addblnames( std::vector<name> patterns ) {
+   void system_contract::denynames( std::vector<name> patterns ) {
       require_auth( get_self() );
 
       check(!patterns.empty(), "Empty list of blacklisted name patterns provided");
@@ -424,7 +424,7 @@ namespace eosiosystem {
       }
    }
 
-   void system_contract::rmblnames( std::vector<name> patterns ) {
+   void system_contract::undenynames( std::vector<name> patterns ) {
       require_auth( get_self() );
 
       check(!patterns.empty(), "Empty list of blacklisted name patterns provided");

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -399,7 +399,7 @@ namespace eosiosystem {
 
    // --------------------------------------------------------------------------
    struct blacklist_manager {
-      blacklist_manager(std::vector<name>& blacklist) : _blacklist(blacklist) {}
+      explicit blacklist_manager(std::vector<name>& blacklist) : _blacklist(blacklist) {}
 
       void add(const std::vector<name>& patterns) const {
          std::unordered_set<name, _hash> already;
@@ -440,7 +440,7 @@ namespace eosiosystem {
       std::vector<name>& _blacklist;
    };
 
-   void system_contract::addblnames( const std::vector<name>& blacklisted_name_patterns ) {
+   void system_contract::addblnames( std::vector<name> blacklisted_name_patterns ) {
       require_auth( get_self() );
 
       check(!blacklisted_name_patterns.empty(), "Empty list of blacklisted name patterns provided");
@@ -456,16 +456,16 @@ namespace eosiosystem {
          blacklist_manager mgr(current);
          mgr.add(blacklisted_name_patterns);
          bl_table.modify(itr, same_payer, [&](auto& blacklist) {
-            std::swap(blacklist.disallowed, current);
+            blacklist.disallowed = std::move(current);
          });
       } else {
          bl_table.emplace(get_self(), [&](auto& blacklist) {
-            blacklist.disallowed = blacklisted_name_patterns;
+            blacklist.disallowed = std::move(blacklisted_name_patterns);
          });
       }
    }
 
-   void system_contract::rmblnames( const std::vector<name>& allowed_name_patterns ) {
+   void system_contract::rmblnames( std::vector<name> allowed_name_patterns ) {
       require_auth( get_self() );
 
       check(!allowed_name_patterns.empty(), "Empty list of blacklisted name patterns provided");
@@ -481,7 +481,7 @@ namespace eosiosystem {
       blacklist_manager mgr(current);
       mgr.remove(allowed_name_patterns);
       bl_table.modify(itr, same_payer, [&](auto& blacklist) {
-         std::swap(blacklist.disallowed, current);
+         blacklist.disallowed = std::move(current);
       });
    }
 

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -398,9 +398,10 @@ namespace eosiosystem {
    }
 
    void system_contract::denynames( const std::vector<name>& patterns ) {
-      require_auth( get_self() );
+      if (patterns.empty())
+         return; // no-op for empty list, consistent with ignoring duplicate names.
 
-      check(!patterns.empty(), "Empty list of blacklisted name patterns provided");
+      require_auth( get_self() );
       check(patterns.size() <= 512, "Cannot provide more than 512 patterns in one action call");
 
       account_name_blacklist_table bl_table(get_self(), get_self().value);
@@ -427,9 +428,10 @@ namespace eosiosystem {
    }
 
    void system_contract::undenynames( const std::vector<name>& patterns ) {
+      if (patterns.empty())
+         return; // no-op for empty list, consistent with ignoring duplicate names.
+      
       require_auth( get_self() );
-
-      check(!patterns.empty(), "Empty list of blacklisted name patterns provided");
       check(patterns.size() <= 512, "Cannot provide more than 512 patterns in one action call");
 
       account_name_blacklist_table bl_table(get_self(), get_self().value);

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -619,7 +619,7 @@ public:
    }
 
    std::vector<name> get_blacklisted_names() const {
-      vector<char> data = get_row_by_id( config::system_account_name, config::system_account_name, "accountnmbl"_n, 0);
+      vector<char> data = get_row_by_id( config::system_account_name, config::system_account_name, "actblacklist"_n, 0);
       if (data.empty())
          return {};
       return abi_ser.binary_to_variant("account_name_blacklist", data, abi_serializer_max_time)["disallowed"].as<std::vector<name>>();

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -619,7 +619,7 @@ public:
    }
 
    std::vector<name> get_blacklisted_names() const {
-      vector<char> data = get_row_by_id( config::system_account_name, config::system_account_name, "actblacklist"_n, 0);
+      vector<char> data = get_row_by_id( config::system_account_name, config::system_account_name, "acctdenylist"_n, 0);
       if (data.empty())
          return {};
       return abi_ser.binary_to_variant("account_name_blacklist", data, abi_serializer_max_time)["disallowed"].as<std::vector<name>>();

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -610,12 +610,12 @@ public:
                          ("active",  authority(get_public_key(account, "active"))));
    }
 
-   action_result addblnames(name acct, const std::vector<name>& patterns) {
-      return push_action(acct, "addblnames"_n, mvo()("patterns", patterns));
+   action_result denynames(name acct, const std::vector<name>& patterns) {
+      return push_action(acct, "denynames"_n, mvo()("patterns", patterns));
    }
 
-   action_result rmblnames(name acct, const std::vector<name>& patterns) {
-      return push_action(acct, "rmblnames"_n, mvo()("patterns", patterns));
+   action_result undenynames(name acct, const std::vector<name>& patterns) {
+      return push_action(acct, "undenynames"_n, mvo()("patterns", patterns));
    }
 
    std::vector<name> get_blacklisted_names() const {

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -610,12 +610,12 @@ public:
                          ("active",  authority(get_public_key(account, "active"))));
    }
 
-   action_result addblnames(name acct, const std::vector<name>& blacklisted_name_patterns) {
-      return push_action(acct, "addblnames"_n, mvo()("blacklisted_name_patterns", blacklisted_name_patterns));
+   action_result addblnames(name acct, const std::vector<name>& patterns) {
+      return push_action(acct, "addblnames"_n, mvo()("patterns", patterns));
    }
 
-   action_result rmblnames(name acct, const std::vector<name>& allowed_name_patterns) {
-      return push_action(acct, "rmblnames"_n, mvo()("allowed_name_patterns", allowed_name_patterns));
+   action_result rmblnames(name acct, const std::vector<name>& patterns) {
+      return push_action(acct, "rmblnames"_n, mvo()("patterns", patterns));
    }
 
    std::vector<name> get_blacklisted_names() const {

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -602,6 +602,29 @@ public:
       return push_transaction( trx );
    }
 
+   action_result _newaccount(name creator, name account) {
+      return push_action(creator, "newaccount"_n, mvo()
+                         ("creator", creator)
+                         ("name",    account)
+                         ("owner",   authority(get_public_key(account, "owner")))
+                         ("active",  authority(get_public_key(account, "active"))));
+   }
+
+   action_result addblnames(name acct, const std::vector<name>& blacklisted_name_patterns) {
+      return push_action(acct, "addblnames"_n, mvo()("blacklisted_name_patterns", blacklisted_name_patterns));
+   }
+
+   action_result rmblnames(name acct, const std::vector<name>& allowed_name_patterns) {
+      return push_action(acct, "rmblnames"_n, mvo()("allowed_name_patterns", allowed_name_patterns));
+   }
+
+   std::vector<name> get_blacklisted_names() const {
+      vector<char> data = get_row_by_id( config::system_account_name, config::system_account_name, "accountnmbl"_n, 0);
+      if (data.empty())
+         return {};
+      return abi_ser.binary_to_variant("account_name_blacklist", data, abi_serializer_max_time)["disallowed"].as<std::vector<name>>();
+   }
+
    action_result push_action( const account_name& signer, const action_name &name, const variant_object &data, bool auth = true ) {
          string action_type_name = abi_ser.get_action_type(name);
 

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -6075,7 +6075,7 @@ BOOST_FIXTURE_TEST_CASE( restrictions_update, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL(denynames("eosio"_n, cat(add4, add4, add4)), success()); // duplicates are ignored even within one call
    BOOST_REQUIRE(get_blacklisted_names() == cat(add1, add2, add4));
 
-   std::vector<name> add5 {""_n, "alice1alice2x"_n};
+   std::vector<name> add5 {""_n, "alice1alice2a"_n};
    BOOST_REQUIRE_EQUAL(denynames("eosio"_n, add5), success());             // invalid names are ignored
    BOOST_REQUIRE(get_blacklisted_names() == cat(add1, add2, add4));
 

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -6074,7 +6074,11 @@ BOOST_FIXTURE_TEST_CASE( restrictions_update, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL(addblnames("eosio"_n, add3), success());            // duplicates are ignored
    BOOST_REQUIRE(get_blacklisted_names() == cat(add1, add2));
 
-   BOOST_REQUIRE_EQUAL(rmblnames("eosio"_n, add1), success());
+   std::vector<name> add4 {"fred.xyz.x"_n, "fred"_n};
+   BOOST_REQUIRE_EQUAL(addblnames("eosio"_n, cat(add4, add4, add4)), success()); // duplicates are ignored even within one call
+   BOOST_REQUIRE(get_blacklisted_names() == cat(add1, add2, add4));
+
+   BOOST_REQUIRE_EQUAL(rmblnames("eosio"_n, cat(add1, add4)), success());
    BOOST_REQUIRE(get_blacklisted_names() == add2);                         // removing names work
 
    BOOST_REQUIRE_EQUAL(rmblnames("eosio"_n, add1), success());             // `rmblnames` silently ignores names not present

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -6075,8 +6075,10 @@ BOOST_FIXTURE_TEST_CASE( restrictions_update, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL(denynames("eosio"_n, cat(add4, add4, add4)), success()); // duplicates are ignored even within one call
    BOOST_REQUIRE(get_blacklisted_names() == cat(add1, add2, add4));
 
-   std::vector<name> add5 {""_n, "alice1alice2a"_n};
-   BOOST_REQUIRE_EQUAL(denynames("eosio"_n, add5), success());             // invalid names are ignored
+   BOOST_REQUIRE_EQUAL(denynames("eosio"_n, {""_n}),
+                       error("assertion failure with message: Empty patterns are not allowed"));
+   BOOST_REQUIRE_EQUAL(denynames("eosio"_n, {"alice1alice2a"_n}),
+                       error("assertion failure with message: Pattern alice1alice2a is not valid"));
    BOOST_REQUIRE(get_blacklisted_names() == cat(add1, add2, add4));
 
    BOOST_REQUIRE_EQUAL(undenynames("eosio"_n, {}), success());             // empty list is silently ignored.

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -6057,23 +6057,25 @@ BOOST_FIXTURE_TEST_CASE( restrictions_update, eosio_system_tester ) try {
 
    // check that `denynames` and `undenynames` update the blacklist as expected
    // ------------------------------------------------------------------------
-   BOOST_REQUIRE_EQUAL(denynames("eosio"_n, {}), error("assertion failure with message: Empty list of blacklisted name patterns provided"));
+   BOOST_REQUIRE_EQUAL(denynames("eosio"_n, {}), success());                // empty list is silently ignored.
    
    std::vector<name> add1 {"bob"_n, "bob.yxz"_n};
    BOOST_REQUIRE_EQUAL(denynames("eosio"_n, add1), success());
-   BOOST_REQUIRE(get_blacklisted_names() == add1);                        // initial add works
+   BOOST_REQUIRE(get_blacklisted_names() == add1);                          // initial add works
 
    std::vector<name> add2 {"alice.xyz.x"_n, "alice"_n};
-   BOOST_REQUIRE_EQUAL(denynames("eosio"_n, add2), success());            // appending works
+   BOOST_REQUIRE_EQUAL(denynames("eosio"_n, add2), success());              // appending works
    BOOST_REQUIRE(get_blacklisted_names() == cat(add1, add2));
 
    std::vector<name> add3 {"bob.yxz"_n, "alice"_n};
-   BOOST_REQUIRE_EQUAL(denynames("eosio"_n, add3), success());            // duplicates are ignored
+   BOOST_REQUIRE_EQUAL(denynames("eosio"_n, add3), success());              // duplicates are ignored
    BOOST_REQUIRE(get_blacklisted_names() == cat(add1, add2));
 
    std::vector<name> add4 {"fred.xyz.x"_n, "fred"_n};
    BOOST_REQUIRE_EQUAL(denynames("eosio"_n, cat(add4, add4, add4)), success()); // duplicates are ignored even within one call
    BOOST_REQUIRE(get_blacklisted_names() == cat(add1, add2, add4));
+
+   BOOST_REQUIRE_EQUAL(undenynames("eosio"_n, {}), success());             // empty list is silently ignored.
 
    BOOST_REQUIRE_EQUAL(undenynames("eosio"_n, cat(add1, add4)), success());
    BOOST_REQUIRE(get_blacklisted_names() == add2);                         // removing names work
@@ -6083,7 +6085,7 @@ BOOST_FIXTURE_TEST_CASE( restrictions_update, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL(undenynames("eosio"_n, add2), success());           // removing all remaining names work
    BOOST_REQUIRE(get_blacklisted_names() == std::vector<name>{});
 
-   BOOST_REQUIRE_EQUAL(denynames("eosio"_n, add2), success());            // and adding some names again for good measure
+   BOOST_REQUIRE_EQUAL(denynames("eosio"_n, add2), success());             // and adding some names again for good measure
    BOOST_REQUIRE(get_blacklisted_names() == add2);
 
 } FC_LOG_AND_RETHROW()

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -6051,39 +6051,39 @@ BOOST_FIXTURE_TEST_CASE( restrictions_update, eosio_system_tester ) try {
    create_accounts_with_resources( accounts );
    const account_name alice = accounts[0];
 
-   // make sure `addblnames` requires "eosio"_n auth
+   // make sure `denynames` requires "eosio"_n auth
    // ----------------------------------------------
-   BOOST_REQUIRE_EQUAL(addblnames(alice, {"bob"_n, "bob.yxz"_n}), error("missing authority of eosio"));
+   BOOST_REQUIRE_EQUAL(denynames(alice, {"bob"_n, "bob.yxz"_n}), error("missing authority of eosio"));
 
-   // check that `addblnames` and `rmblnames` update the blacklist as expected
+   // check that `denynames` and `undenynames` update the blacklist as expected
    // ------------------------------------------------------------------------
-   BOOST_REQUIRE_EQUAL(addblnames("eosio"_n, {}), error("assertion failure with message: Empty list of blacklisted name patterns provided"));
+   BOOST_REQUIRE_EQUAL(denynames("eosio"_n, {}), error("assertion failure with message: Empty list of blacklisted name patterns provided"));
    
    std::vector<name> add1 {"bob"_n, "bob.yxz"_n};
-   BOOST_REQUIRE_EQUAL(addblnames("eosio"_n, add1), success());
-   BOOST_REQUIRE(get_blacklisted_names() == add1);                         // initial add works
+   BOOST_REQUIRE_EQUAL(denynames("eosio"_n, add1), success());
+   BOOST_REQUIRE(get_blacklisted_names() == add1);                        // initial add works
 
    std::vector<name> add2 {"alice.xyz.x"_n, "alice"_n};
-   BOOST_REQUIRE_EQUAL(addblnames("eosio"_n, add2), success());            // appending works
+   BOOST_REQUIRE_EQUAL(denynames("eosio"_n, add2), success());            // appending works
    BOOST_REQUIRE(get_blacklisted_names() == cat(add1, add2));
 
    std::vector<name> add3 {"bob.yxz"_n, "alice"_n};
-   BOOST_REQUIRE_EQUAL(addblnames("eosio"_n, add3), success());            // duplicates are ignored
+   BOOST_REQUIRE_EQUAL(denynames("eosio"_n, add3), success());            // duplicates are ignored
    BOOST_REQUIRE(get_blacklisted_names() == cat(add1, add2));
 
    std::vector<name> add4 {"fred.xyz.x"_n, "fred"_n};
-   BOOST_REQUIRE_EQUAL(addblnames("eosio"_n, cat(add4, add4, add4)), success()); // duplicates are ignored even within one call
+   BOOST_REQUIRE_EQUAL(denynames("eosio"_n, cat(add4, add4, add4)), success()); // duplicates are ignored even within one call
    BOOST_REQUIRE(get_blacklisted_names() == cat(add1, add2, add4));
 
-   BOOST_REQUIRE_EQUAL(rmblnames("eosio"_n, cat(add1, add4)), success());
+   BOOST_REQUIRE_EQUAL(undenynames("eosio"_n, cat(add1, add4)), success());
    BOOST_REQUIRE(get_blacklisted_names() == add2);                         // removing names work
 
-   BOOST_REQUIRE_EQUAL(rmblnames("eosio"_n, add1), success());             // `rmblnames` silently ignores names not present
+   BOOST_REQUIRE_EQUAL(undenynames("eosio"_n, add1), success());           // `undenynames` silently ignores names not present
 
-   BOOST_REQUIRE_EQUAL(rmblnames("eosio"_n, add2), success());             // removing all remaining names work
+   BOOST_REQUIRE_EQUAL(undenynames("eosio"_n, add2), success());           // removing all remaining names work
    BOOST_REQUIRE(get_blacklisted_names() == std::vector<name>{});
 
-   BOOST_REQUIRE_EQUAL(addblnames("eosio"_n, add2), success());            // and adding some names again for good measure
+   BOOST_REQUIRE_EQUAL(denynames("eosio"_n, add2), success());            // and adding some names again for good measure
    BOOST_REQUIRE(get_blacklisted_names() == add2);
 
 } FC_LOG_AND_RETHROW()
@@ -6170,7 +6170,7 @@ BOOST_AUTO_TEST_CASE( restrictions_checking ) try {
    r.create_accounts({"thereal3safe"_n, "esafe"_n}, false); // false means just bid for the name but don't create the account
 
    std::vector<name> add { "esafe"_n, "e.safe"_n };
-   BOOST_REQUIRE_EQUAL(r.addblnames("eosio"_n, add), r.success());
+   BOOST_REQUIRE_EQUAL(r.denynames("eosio"_n, add), r.success());
 
    r.check_disallowed(
       {
@@ -6207,7 +6207,7 @@ BOOST_AUTO_TEST_CASE( eosio_restrictions_checking ) try {
    r.create_accounts({"thereal3safe"_n, "esafe"_n}, false);  // false means just bid for the name but don't create the account
 
    std::vector<name> add { "esafe"_n, "e.safe"_n };
-   BOOST_REQUIRE_EQUAL(r.addblnames("eosio"_n, add), r.success());
+   BOOST_REQUIRE_EQUAL(r.denynames("eosio"_n, add), r.success());
 
    r.check_allowed(   // these are allowed for "eosio"_n because "eosio"_n is not restricted.
       {

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -6093,10 +6093,11 @@ BOOST_FIXTURE_TEST_CASE( restrictions_update, eosio_system_tester ) try {
 struct name_restrictions {
    std::pair<bool, base_tester::action_result> check_allowed(name n) {
       auto suffix = n.suffix();
-      auto actual_creator = suffix == n || creator == "eosio"_n ? creator : suffix;
+      bool toplevel_account = suffix == n;
+      auto actual_creator = (toplevel_account || creator == "eosio"_n) ? creator : suffix;
       try {
          tester.create_account_with_resources(n, actual_creator, 100'000u);
-         if (suffix.empty()) {
+         if (toplevel_account) {
             tester.transfer("eosio"_n, n, core_sym::from_string("1000.0000"));
             tester.stake_with_transfer("eosio"_n, n, core_sym::from_string("100.0000"), core_sym::from_string("100.0000"));
          }
@@ -6165,10 +6166,6 @@ BOOST_FIXTURE_TEST_CASE( restrictions_checking, eosio_system_tester ) try {
    
    // and then do the actual tests
    // ----------------------------
-   const std::vector<account_name> accounts = { "alice"_n };
-   create_accounts_with_resources( accounts );
-   const account_name alice = accounts[0];
-
    name_restrictions r{*this, "fred"_n};
 
    std::vector<name> add { "esafe"_n, "e.safe"_n };

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -6075,6 +6075,10 @@ BOOST_FIXTURE_TEST_CASE( restrictions_update, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL(denynames("eosio"_n, cat(add4, add4, add4)), success()); // duplicates are ignored even within one call
    BOOST_REQUIRE(get_blacklisted_names() == cat(add1, add2, add4));
 
+   std::vector<name> add5 {""_n, "alice1alice2x"_n};
+   BOOST_REQUIRE_EQUAL(denynames("eosio"_n, add5), success());             // invalid names are ignored
+   BOOST_REQUIRE(get_blacklisted_names() == cat(add1, add2, add4));
+
    BOOST_REQUIRE_EQUAL(undenynames("eosio"_n, {}), success());             // empty list is silently ignored.
 
    BOOST_REQUIRE_EQUAL(undenynames("eosio"_n, cat(add1, add4)), success());


### PR DESCRIPTION
Resolves #186

Note: the `struct canon_name_t` implements the checks of whether a `name` is a subset of another `name`. For performance reasons, this is implemented by shifting,  masking and comparing the `uint64_t` value. 

Probably the equivalent implementation below using strings is easier to understand (but less efficient), which is why I used the `uint64_t` version, but this could be changed if needed.

```
struct canon_name_t {
   std::string _pattern;

   canon_name_t(name n) : _pattern(n.to_string()) {}

   size_t size() const { return _pattern.size(); }

   bool is_suffix_of(const canon_name_t& target) const {
      assert(size() < target.size());
      size_t diff = target.size() - size();
      return strcmp(&_pattern[0], &target._pattern[diff]) == 0 && target._pattern[diff-1] == '.';
   }

   bool found_in(const canon_name_t& target) const {
      assert(size() < target.size());
      auto sz = size();
      size_t diff = target.size() - sz + 1;
      for (size_t i=0; i<diff; ++i)
         if (strncmp(&_pattern[0], &target._pattern[i], sz) == 0)
            return true;
      return false;
   }
};
```

### From @arhag:

We want to add a restriction in the system contract when creating a new account.

These additional restrictions will not take affect is the action has the authority of eosio (which we can check with has_auth).

The additional restrictions are as follows:

We lookup restricted strings in some table that can be modified only by eosio permission. If one of those restricted strings can be found anywhere within the desired name of the account to create (with one exception), then the contract rejects creating the account. The one exception is if a restricted string forms a valid suffix of the desired account, then that restricted string is not an enforced restriction on that account creation.

So for example, consider if the BPs add the strings "esafe" and "e.safe" to the table:

The following account names cannot be created (no restriction on accounts that were already created with these names prior to adding the restricted strings to the contract):
- `therealesafe`
- `esafe.xyz` (cannot even be created by the xyz account)
- `e.safe.abc` (cannot even be created by the safe.abc account)
- `12e.safe.abc` (cannot even be created by the safe.abc account)
- `esafe.e.safe` (cannot even be created by the e.safe account)

But the following account names can be created:
+ `thereal3safe` (can be created by anyone)
+ `esave.xyz` (can be created by the xyz account)
+ `esaf.e12` (can be created by the e12 account)
+ `esa.fe` (can be created by the fe account)
+ `esafe.esafe` (can be created by the esafe account)
+ `e.esafe` (can be created by the esafe account)
+ `e.safe` (can be created by the safe account)
+ `a.e.safe` (can be created by the e.safe account)
+ `esafe` (can only be created by someone who won the name auction bid for "esafe" or by eosio)

Note that `esafe` and `e.safe` restricted strings are meant only to be examples. They are not the actual restricted strings we intend the BPs to add in conjunction with this feature that we develop.

The requirements above are somewhat flexible in the sense that we can negotiate the actual rules for the restricted name (but then we would still need to make sure the allowed and disallowed tests cases are consistently reflecting the new rules). They are designed with a mind towards reasonable trade-offs between ease of implementation and the goal of restricting people from acquiring names that appear to be official while also still allowing the people who have control over the official accounts to create sub-accounts without require eosio permission each time.

But there may be some opportunity to change the requirements, especially if it reduces implementation complexity further without compromising the goal. There is more that can be done to better achieve the goal but at the cost of greater implementation complexity, so that is likely not in scope. 

For example, we aren't interested in the code automatically replacing characters in the explicitly added restricted strings with other similar appearing characters (for example l and 1) when it is enforcing its restrictions on new account names. We would rather have the BPs add the additional restricted strings with replaced homoglyphs manually. There is in theory a combination explosion possible there, but in practice since we are dealing with Antelope names which are very restrictive, there are only a few homoglyphs and the total length of the restricted strings is bounded above by 12 anyway.

There is an additional cost on every newaccount action that scales with the number of entries in the restrticted strings table. So we want to limit the number of restricted strings in practice to a very small number. In practice, we may only have a single entry. But since we may have a handful, and every table row lookup adds extra cost, it makes sense for the implementation to use a singleton table and put all restricted strings into one vector in the singleton table row (that way only one table lookup is needed for each newaccount action).