### PR TITLE
Add a `hash` / `reveal` mechanism to avoid revealing the reserved account names when activating the blacklist.

### DIFF
--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -1004,6 +1004,18 @@ namespace eosiosystem {
          void denyhashadd( const checksum256& hash );
 
          /**
+          * Remove a hash value computed from a vector of names. Will trigger an exception if the hash is absent,
+          * i.e. if it was never added via `denyhashadd`, or if it was removed when the corresponding name vector
+          * was added via `denynames`.
+          *
+          * requires "eosio"_n permission
+          *
+          * @param hash - a hash value computed from a vector of names.
+          */
+         [[eosio::action]]
+         void denyhashrm( const checksum256& hash );
+
+         /**
           * Add names to the `account_name_blacklist` singleton.
           *
           * The `account_name_blacklist` singleton contains a vector of names, each of which is a pattern that

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -992,7 +992,7 @@ namespace eosiosystem {
          /**
           * Store a hash value computed from a vector of names.
           *
-          * Once this hash has been store in the blockchain (a privileged operation), any account can call the
+          * Once this hash has been stored in the blockchain (a privileged operation), any account can call the
           * `denynames` action to add the vector of name patterns that this hash was computed from to the
           * `account_name_blacklist`.
           *

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -985,6 +985,8 @@ namespace eosiosystem {
           * Computes a hash for a vector of names
           *
           * @param patterns - vector of names.
+          *
+          * This is a read-only action. 
           */
          [[eosio::action]]
          checksum256 denyhashcalc( const std::vector<name>& patterns );

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -391,10 +391,10 @@ namespace eosiosystem {
 
    // Store hash values allowing account blacklist names to be added to `account_name_blacklist_table`
    struct [[eosio::table("acctdenyhash"), eosio::contract("eosio.system")]] deny_hash {
-      uint64_t       id;                   // automatically generated ID for the key in the table
-      checksum256  hash;                 // sha256 hash computed over a `vector<name>` and allowing
-                                           // said vector to be added to `account_name_blacklist_table`
-      uint64_t       primary_key() const { return id; }
+      uint64_t     id;                       // automatically generated ID for the key in the table
+      checksum256  hash;                     // sha256 hash computed over a `vector<name>` and allowing
+                                             // said vector to be added to `account_name_blacklist_table`
+      uint64_t     primary_key() const { return id; }
       checksum256  by_hash()     const { return hash; }
    };
 

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -406,6 +406,7 @@ namespace eosiosystem {
          check(pattern.valid(),
                n.value ? ("Pattern " + n.to_string() + " is not valid") : "Empty patterns are not allowed");
       }
+      static_assert(sizeof(name) == sizeof(uint64_t));
       return eosio::sha256(reinterpret_cast<const char*>(patterns.data()), patterns.size() * sizeof(name));
    }
 

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -420,6 +420,16 @@ namespace eosiosystem {
       dh_table.emplace(get_self(), [&](auto& row) { row.hash = hash; });
    }
 
+   void system_contract::denyhashrm( const checksum256& hash ) {
+      require_auth( get_self() );
+
+      deny_hash_table dh_table(get_self(), get_self().value);
+      auto idx = dh_table.get_index<"byhash"_n>();
+      auto itr = idx.find(hash);
+      check(itr != idx.end(), "Trying to remove a deny hash which is not present");
+      idx.erase(itr);
+   }
+
    void system_contract::denynames( const std::vector<name>& patterns ) {
       // no auth necessary since the hash verification is enough
       

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -436,9 +436,7 @@ namespace eosiosystem {
    void system_contract::denynames( const std::vector<name>& patterns ) {
       // no auth necessary since the hash verification is enough
       
-      if (patterns.empty())
-         return; // no-op for empty list, consistent with ignoring duplicate names.
-
+      check(!patterns.empty(), "No patterns provided");
       check(patterns.size() <= 512, "Cannot provide more than 512 patterns in one action call");
 
       deny_hash_table dh_table(get_self(), get_self().value);

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -610,6 +610,21 @@ public:
                          ("active",  authority(get_public_key(account, "active"))));
    }
 
+   std::optional<fc::sha256> denyhashcalc(name acct, const std::vector<name>& patterns) {
+      try {
+         auto trace = base_tester::push_action(config::system_account_name, "denyhashcalc"_n, acct, mvo()("patterns", patterns));
+         auto v = trace->action_traces[0].return_value;
+         fc::sha256 hash = fc::sha256(v.data(), v.size());
+         return hash;
+      } catch (const fc::exception& ex) {
+         return {};
+      }
+   }
+
+   action_result denyhashadd(name acct, const sha256& hash) {
+      return push_action(acct, "denyhashadd"_n, mvo()("hash", hash));
+   }
+
    action_result denynames(name acct, const std::vector<name>& patterns) {
       return push_action(acct, "denynames"_n, mvo()("patterns", patterns));
    }

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -625,6 +625,10 @@ public:
       return push_action(acct, "denyhashadd"_n, mvo()("hash", hash));
    }
 
+   action_result denyhashrm(name acct, const sha256& hash) {
+      return push_action(acct, "denyhashrm"_n, mvo()("hash", hash));
+   }
+
    action_result denynames(name acct, const std::vector<name>& patterns) {
       return push_action(acct, "denynames"_n, mvo()("patterns", patterns));
    }

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -6245,6 +6245,9 @@ BOOST_AUTO_TEST_CASE( eosio_restrictions_checking ) try {
    std::vector<name> add1 { "esafe"_n };
    auto add1_hash = *r.denyhashcalc("eosio"_n, add1);
    BOOST_REQUIRE_EQUAL(r.denyhashadd("eosio"_n, add1_hash), r.success());
+   BOOST_REQUIRE_EQUAL(r.denyhashadd("eosio"_n, add1_hash),
+                       r.error("assertion failure with message: Trying to add a deny hash which is already present"));
+
    BOOST_REQUIRE_EQUAL(r.denynames("eosio"_n, add1), r.success());        // `denynames` will remove add1_hash
    BOOST_REQUIRE_EQUAL(r.denyhashrm("eosio"_n, add1_hash),
                        r.error("assertion failure with message: Trying to remove a deny hash which is not present"));  

--- a/tests/eosio.system_tests.cpp
+++ b/tests/eosio.system_tests.cpp
@@ -6071,7 +6071,8 @@ BOOST_FIXTURE_TEST_CASE( restrictions_update, eosio_system_tester ) try {
    BOOST_REQUIRE_EQUAL(denynames(alice, add1), success());                  // and then anyone (alice here) can deny the name patterns
    BOOST_REQUIRE(get_blacklisted_names() == add1);                          // newly added names are present in blacklist
 
-   BOOST_REQUIRE_EQUAL(denynames(alice, {}), success());                    // empty list is silently ignored.
+   BOOST_REQUIRE_EQUAL(denynames(alice, {}),
+                       error("assertion failure with message: No patterns provided"));
    
    BOOST_REQUIRE_EQUAL(denynames(alice, add1),                              // hash was removed when we added the `add1` names above
                        error("assertion failure with message: Verification hash not found in denyhash table"));


### PR DESCRIPTION
Resolves #186.

